### PR TITLE
expanded GetFileDoc response and some restructuring

### DIFF
--- a/routers/docs.py
+++ b/routers/docs.py
@@ -2,11 +2,10 @@ import http.client
 import logging
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
-from schemas.documentation_generation import DocsStatusEnum, GenerateFileDocsRequest, GenerateFileDocsResponse, \
+from schemas.documentation_generation import GenerateFileDocsRequest, GenerateFileDocsResponse, \
     GetFileDocsResponse
 from services.clients.github_client import GitHubClient, get_github_client
 from services.documentation_service import DocumentationService, get_documentation_service
-from services.clients.firebase_client import FirebaseClient, get_firebase_client
 
 router = APIRouter()
 
@@ -23,13 +22,14 @@ async def generate_file_docs(
             raise HTTPException(status_code=http.client.UNPROCESSABLE_ENTITY,
                                 detail="Required field 'github_url' is missing.")
 
-        # validate no error is thrown
+        # TODO: create better validation of proper GitHub links
         github_client.extract_github_info(generate_file_docs_request.github_url)
 
         # add document to firebase
         document_ref = documentation_service.create_document_generation_job(
             background_tasks,
-            generate_file_docs_request.github_url
+            generate_file_docs_request.github_url,
+            generate_file_docs_request.model
         )
 
         return GenerateFileDocsResponse(
@@ -44,31 +44,14 @@ async def generate_file_docs(
 
 
 @router.get("/file-docs/{doc_id}")
-async def get_file_docs(
+async def get_file_doc(
         doc_id: str,
-        firebase_client: FirebaseClient = Depends(get_firebase_client),
+        documentation_service: DocumentationService = Depends(get_documentation_service),
 ) -> GetFileDocsResponse:
     try:
-        document_dict = firebase_client.get_document(firebase_client.TEST_COLLECTION, doc_id).to_dict()
-
-        if not document_dict:
-            raise HTTPException(status_code=http.client.NOT_FOUND, detail=f"Document {doc_id} not found.")
-
-        status = DocsStatusEnum(document_dict.get("status"))
-        blob_url = document_dict.get("bucket_url")
-
-        # if it is completed get the content, otherwise return None
-        content = None
-        if status == DocsStatusEnum.COMPLETED:
-            content = firebase_client.get_blob(blob_url).download_as_string()
-
-        return GetFileDocsResponse(
-            id=doc_id,
-            status=status,
-            content=content
-        )
+        doc = documentation_service.get_documentation_with_content(doc_id)
+        return GetFileDocsResponse(**doc)
     except ValueError as e:
         raise HTTPException(status_code=http.client.BAD_REQUEST, detail=str(e))
     except Exception as e:
         logging.error(e)
-        raise HTTPException(status_code=http.client.INTERNAL_SERVER_ERROR)

--- a/routers/docs.py
+++ b/routers/docs.py
@@ -26,7 +26,7 @@ async def generate_file_docs(
         github_client.extract_github_info(generate_file_docs_request.github_url)
 
         # add document to firebase
-        document_ref = documentation_service.create_document_generation_job(
+        doc_id = documentation_service.create_document_generation_job(
             background_tasks,
             generate_file_docs_request.github_url,
             generate_file_docs_request.model
@@ -34,7 +34,7 @@ async def generate_file_docs(
 
         return GenerateFileDocsResponse(
             message="Documentation generation has been started.",
-            id=document_ref.id
+            id=doc_id
         )
     except ValueError as e:
         raise HTTPException(status_code=http.client.BAD_REQUEST, detail=str(e))

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -33,6 +33,7 @@ class FirestoreDocumentationUpdateModel(BaseModel):
 
 class GenerateFileDocsRequest(BaseModel):
     github_url: str
+    model: LlmModelEnum = LlmModelEnum.MIXTRAL
 
 
 class GenerateFileDocsResponse(BaseModel):
@@ -44,5 +45,6 @@ class GenerateFileDocsResponse(BaseModel):
 
 class GetFileDocsResponse(BaseModel):
     id: str
+    github_url: str
     status: str
     content: str | None

--- a/services/clients/llm_client.py
+++ b/services/clients/llm_client.py
@@ -4,6 +4,6 @@ from abc import ABC, abstractmethod
 
 class LLMClient(ABC):
     @abstractmethod
-    async def generate_text(self, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
+    async def generate_text(self, model:str, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
         """Abstract method for generating text."""
         pass

--- a/services/clients/openai_client.py
+++ b/services/clients/openai_client.py
@@ -6,15 +6,14 @@ from openai import AsyncOpenAI
 
 
 class OpenAIClient(LLMClient):
-    def __init__(self, api_key: str, base_url: str, model: str):
+    def __init__(self, api_key: str, base_url: str):
         self.api_key = api_key
         self.base_url = base_url
-        self.model = model
         self.openai = AsyncOpenAI(api_key=self.api_key, base_url=base_url)
 
-    async def generate_text(self, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
+    async def generate_text(self, model: str, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
         completion = await self.openai.chat.completions.create(
-            model=self.model,
+            model=model,
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt}
@@ -26,7 +25,7 @@ class OpenAIClient(LLMClient):
         # return """This is an example response"""
 
 
-def get_openai_client(model):
+def get_openai_client():
     api_key = os.getenv("OPENAI_API_KEY")
     base_url = os.getenv("OPENAI_BASE_URL")
-    return OpenAIClient(api_key, base_url, model)
+    return OpenAIClient(api_key, base_url)

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -1,10 +1,11 @@
 import asyncio
-from typing import Coroutine, List, Any
+import http.client
+from typing import Coroutine, List, Any, Dict
 from schemas.documentation_generation import DocsStatusEnum, FirestoreDocumentationCreateModel, \
     FirestoreDocumentationUpdateModel, GeneratedDocResponse, LlmModelEnum
 from services.clients.firebase_client import FirebaseClient, get_firebase_client
 from google.cloud.firestore_v1 import DocumentReference
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, HTTPException
 
 from dotenv import load_dotenv
 
@@ -12,33 +13,42 @@ from services.clients.llm_client import LLMClient
 from services.clients.openai_client import get_openai_client
 from services.clients.github_client import GitHubClient, get_github_client
 
+SYSTEM_PROMPT_FOR_FILES = """
+Your job is to provide very high-level documentation of code provided to you.
+    
+You will respond in Markdown format, with the following sections:
+## Description: (a string less than 100 words)
+## Insights: ([string, string, string])
+
+Here is the code:
+"""
+
 
 class DocumentationService:
     def __init__(self, llm_client: LLMClient, github_client: GitHubClient, firebase_client: FirebaseClient):
         self.llm_client = llm_client
         self.github_client = github_client
         self.firebase_client = firebase_client
-        self.system_prompt_for_file = """
-            Your job is to provide very high-level documentation of code provided to you.
-    
-            You will respond in Markdown format, with the following sections:
-            ## Description: (a string less than 100 words)
-            ## Insights: ([string, string, string])
-            
-            Here is the code:
-            """
+        self.system_prompt_for_file = SYSTEM_PROMPT_FOR_FILES
 
-    async def generate_doc_for_github_file(self, file_url: str):
+    async def generate_doc_for_github_file(
+            self,
+            file_url: str,
+            model: LlmModelEnum = LlmModelEnum.MIXTRAL
+    ):
         if not file_url:
             raise ValueError("File url cannot be empty")
 
         file_content = self.github_client.read_file(file_url)
 
         llm_response = await self.llm_client.generate_text(
+            model=model,
             prompt=file_content,
             system_prompt=self.system_prompt_for_file,
             max_tokens=500
         )
+        if llm_response[0] == " ":
+            llm_response = llm_response[1:]
 
         response = GeneratedDocResponse(content=llm_response)
 
@@ -59,8 +69,9 @@ class DocumentationService:
             self,
             firebase_file_id: str,
             github_url: str,
+            model: LlmModelEnum = None
     ):
-        generated_docs = asyncio.run(self.generate_doc_for_github_file(github_url))
+        generated_docs = asyncio.run(self.generate_doc_for_github_file(github_url, model))
 
         blob_url = self.firebase_client.get_blob_url(firebase_file_id)
 
@@ -69,8 +80,7 @@ class DocumentationService:
         self.firebase_client.update_document(
             FirebaseClient.TEST_COLLECTION,
             firebase_file_id,
-            FirestoreDocumentationUpdateModel
-            (
+            FirestoreDocumentationUpdateModel(
                 bucket_url=blob_url,
                 status=DocsStatusEnum.COMPLETED
             ).model_dump()
@@ -79,12 +89,12 @@ class DocumentationService:
     def create_document_generation_job(
             self,
             background_tasks: BackgroundTasks,
-            github_url: str
+            github_url: str,
+            model: LlmModelEnum = None
     ) -> DocumentReference:
         document_ref = self.firebase_client.add_document(
             FirebaseClient.TEST_COLLECTION,
-            FirestoreDocumentationCreateModel
-            (
+            FirestoreDocumentationCreateModel(
                 github_url=github_url,
                 bucket_url=None,
                 status=DocsStatusEnum.STARTED
@@ -95,15 +105,44 @@ class DocumentationService:
         background_tasks.add_task(
             self.generate_documentation_background,
             document_ref.id,
-            github_url
+            github_url,
+            model
         )
 
         return document_ref
 
+    def get_documentation(self, doc_id: str) -> Dict[str, Any]:
+        document_snapshot = self.firebase_client.get_document(
+            self.firebase_client.TEST_COLLECTION,
+            doc_id
+        )
 
-def get_documentation_service(model: LlmModelEnum = LlmModelEnum.MIXTRAL) -> DocumentationService:
+        if not document_snapshot:
+            raise HTTPException(status_code=http.client.NOT_FOUND, detail=f"Document {doc_id} not found.")
+
+        # adding id field since Firestore does not do it naturally
+        document_dict = document_snapshot.to_dict()
+        document_dict["id"] = document_snapshot.id
+
+        return document_dict
+
+    def get_documentation_with_content(self, doc_id: str) -> Dict[str, Any]:
+        doc = self.get_documentation(doc_id)
+
+        status = DocsStatusEnum(doc.get("status"))
+        blob_url = doc.get("bucket_url")
+
+        # if it is completed get the content, otherwise return None
+        doc["content"] = None
+        if status == DocsStatusEnum.COMPLETED:
+            doc["content"] = self.firebase_client.get_blob(blob_url).download_as_text()
+
+        return doc
+
+
+def get_documentation_service() -> DocumentationService:
     """Initializes the service with any dependencies it needs."""
-    openai_client = get_openai_client(model)
+    openai_client = get_openai_client()
     github_client = get_github_client()
     firebase_client = get_firebase_client()
     return DocumentationService(openai_client, github_client, firebase_client)

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -19,8 +19,6 @@ Your job is to provide very high-level documentation of code provided to you.
 You will respond in Markdown format, with the following sections:
 ## Description: (a string less than 100 words)
 ## Insights: ([string, string, string])
-
-Here is the code:
 """
 
 
@@ -41,9 +39,11 @@ class DocumentationService:
 
         file_content = self.github_client.read_file(file_url)
 
+        user_prompt = "Here is the code: \n" + file_content
+
         llm_response = await self.llm_client.generate_text(
             model=model,
-            prompt=file_content,
+            prompt=user_prompt,
             system_prompt=self.system_prompt_for_file,
             max_tokens=500
         )


### PR DESCRIPTION
- Restructured the `GET /file-docs/{doc_id}` router to call business logic for the main processing steps.
- `model` parameter is now part of the request body and no longer injected into DocumentationService in creation, but rather passed down as a parameter to the needed functions.
- Removed a single space character (" ") that Anyscale adds to the beginning of all it's LLM responses.