### PR TITLE
added auth check to endpoints and better error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY . /code/rocketdocs
 
-EXPOSE 80
+EXPOSE 443
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "443", "--ssl-keyfile", "./creds/privkey.pem", "--ssl-certfile", "./creds/fullchain.pem"]

--- a/routers/docs.py
+++ b/routers/docs.py
@@ -1,57 +1,49 @@
-import http.client
-import logging
+from typing import Dict, Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+
 from schemas.documentation_generation import GenerateFileDocsRequest, GenerateFileDocsResponse, \
     GetFileDocsResponse
 from services.clients.github_client import GitHubClient, get_github_client
 from services.documentation_service import DocumentationService, get_documentation_service
+from routers.utils.auth import get_user_token
 
 router = APIRouter()
 
 
-@router.post("/file-docs", status_code=http.client.ACCEPTED)
+@router.post("/file-docs", status_code=status.HTTP_202_ACCEPTED)
 async def generate_file_docs(
         generate_file_docs_request: GenerateFileDocsRequest,
         background_tasks: BackgroundTasks,
         documentation_service: DocumentationService = Depends(get_documentation_service),
-        github_client: GitHubClient = Depends(get_github_client)
+        github_client: GitHubClient = Depends(get_github_client),
+        user: Dict[str, Any] = Depends(get_user_token),
 ) -> GenerateFileDocsResponse:
-    try:
-        if not generate_file_docs_request.github_url:
-            raise HTTPException(status_code=http.client.UNPROCESSABLE_ENTITY,
-                                detail="Required field 'github_url' is missing.")
+    if not generate_file_docs_request.github_url:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail="Required field 'github_url' is missing.")
 
-        # TODO: create better validation of proper GitHub links
-        github_client.extract_github_info(generate_file_docs_request.github_url)
+    # TODO: create better validation of proper GitHub links
+    github_client.extract_github_info(generate_file_docs_request.github_url)
 
-        # add document to firebase
-        doc_id = documentation_service.create_document_generation_job(
-            background_tasks,
-            generate_file_docs_request.github_url,
-            generate_file_docs_request.model
-        )
+    # add document to firebase
+    doc_id = documentation_service.create_document_generation_job(
+        background_tasks,
+        generate_file_docs_request.github_url,
+        generate_file_docs_request.model
+    )
 
-        return GenerateFileDocsResponse(
-            message="Documentation generation has been started.",
-            id=doc_id
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=http.client.BAD_REQUEST, detail=str(e))
-    except Exception as e:
-        logging.error(e)
-        raise HTTPException(status_code=http.client.INTERNAL_SERVER_ERROR)
+    return GenerateFileDocsResponse(
+        message="Documentation generation has been started.",
+        id=doc_id
+    )
 
 
 @router.get("/file-docs/{doc_id}")
 async def get_file_doc(
         doc_id: str,
         documentation_service: DocumentationService = Depends(get_documentation_service),
+        user: Dict[str, Any] = Depends(get_user_token),
 ) -> GetFileDocsResponse:
-    try:
-        doc = documentation_service.get_documentation_with_content(doc_id)
-        return GetFileDocsResponse(**doc)
-    except ValueError as e:
-        raise HTTPException(status_code=http.client.BAD_REQUEST, detail=str(e))
-    except Exception as e:
-        logging.error(e)
+    doc = documentation_service.get_documentation_with_content(doc_id)
+    return GetFileDocsResponse(**doc)

--- a/routers/utils/auth.py
+++ b/routers/utils/auth.py
@@ -1,0 +1,24 @@
+import logging
+from typing import Dict, Any
+
+from fastapi import Depends, HTTPException, Response, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from firebase_admin import auth
+
+
+def get_user_token(
+        res: Response,
+        credential: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False))
+) -> Dict[str, Any]:
+    if not credential:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            headers={'WWW-Authenticate': 'Bearer realm="auth_required"'})
+    try:
+        decoded_token = auth.verify_id_token(credential.credentials)
+    except Exception as e:
+        logging.error(e)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail=f"Invalid authentication from Firebase. {e}",
+                            headers={'WWW-Authenticate': 'Bearer error="invalid_token"'})
+    res.headers['WWW-Authenticate'] = 'Bearer realm="auth_required"'
+    return decoded_token

--- a/services/clients/firebase_client.py
+++ b/services/clients/firebase_client.py
@@ -26,6 +26,7 @@ class FirebaseClient:
 
     def get_documentation(self, doc_id) -> Dict[str, Any] | None:
         document_snapshot = self._get(self.DOCUMENTATION_COLLECTION, doc_id)
+
         if not document_snapshot:
             return None
 
@@ -51,7 +52,7 @@ class FirebaseClient:
 
     @staticmethod
     def get_blob_url(blob_name, folder="repo") -> str:
-        return f"/{folder}/{blob_name}"
+        return f"{folder}/{blob_name}"
 
     def _add(self, collection_path, data) -> DocumentReference:
         collection_ref = self.db.collection(collection_path)

--- a/services/clients/github_client.py
+++ b/services/clients/github_client.py
@@ -7,6 +7,7 @@ import requests
 from typing import Optional
 
 from dotenv import load_dotenv
+from fastapi import HTTPException, status
 
 
 class GitHubClient:
@@ -27,7 +28,8 @@ class GitHubClient:
 
         data = request.json()
         if "type" in data and data["type"] == "dir":
-            raise ValueError(f"{github_url} is a folder, not a file.")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=f"{github_url} is not a file.")
 
         file_content = data["content"]
         file_content_encoding = data.get('encoding')
@@ -44,7 +46,8 @@ class GitHubClient:
         path_parts = url_parts.path.strip('/').split('/')
 
         if len(path_parts) < 2:
-            raise ValueError("Invalid GitHub url")
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Invalid GitHub url")
 
         username = path_parts[0]
         repository_name = path_parts[1]

--- a/services/clients/llm_client.py
+++ b/services/clients/llm_client.py
@@ -1,9 +1,8 @@
-from typing import Optional
 from abc import ABC, abstractmethod
 
 
 class LLMClient(ABC):
     @abstractmethod
-    async def generate_text(self, model:str, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
+    async def generate_text(self, model: str, prompt: str, system_prompt: str, max_tokens: int | None = None) -> str:
         """Abstract method for generating text."""
         pass

--- a/services/clients/openai_client.py
+++ b/services/clients/openai_client.py
@@ -1,6 +1,5 @@
 import os
 
-from typing import Optional
 from services.clients.llm_client import LLMClient
 from openai import AsyncOpenAI
 
@@ -22,7 +21,6 @@ class OpenAIClient(LLMClient):
         )
 
         return completion.choices[0].message.content
-        # return """This is an example response"""
 
 
 def get_openai_client():


### PR DESCRIPTION
Jira Task: [Firebase Auth](https://rocketdocsio.atlassian.net/browse/KAN-55?atlOrigin=eyJpIjoiM2JmN2M2OGQwMTA4NGY5YWI2NGU4ZGFiMzZjZWQ2NDAiLCJwIjoiaiJ9)

### Changes
- New function `get_user_token` will validate user exists in our Firebase Auth. If not, a 401 error is returned.
- Slight rework of error handling. Replaced general exceptions like `ValueError` (which indicates a user-input value was invalid) with FastAPI's `HTTPException` in hopes of providing more detailed error codes.

### How to use
#### Backend Team development
As long as a valid user exists in our Firebase Auth. And you get the `Web API Key` from the Firebase console. We can make a `POST` request like so:
(feel free to store it in Postman/Insomnia/etc...)
```
curl --request POST \
  --url 'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=[WebApiKey]' \
  --header 'Content-Type: application/json' \
  --data '{
	"email": "user.email@domain.com",
	"password": "the_password",
	"returnSecureToken": true
}'
```

This will return an object that contains an `idToken`, along with other data:
```
{
  "idToken": "..."
}
```

The token lasts for 1 hour and can be put into the interactive FastAPI docs:
<img width="1109" alt="image" src="https://github.com/KTujjar/rocketdocs/assets/75096034/361e189e-b660-48ee-9846-7193d0d4871a">
Or into a request's header.

#### Frontend Team
The frontend team will authenticate with Firebase Auth on their end, and send us the user token through the request header.