### PR TITLE
added identifier service

### DIFF
--- a/routers/docs.py
+++ b/routers/docs.py
@@ -48,7 +48,7 @@ async def get_file_docs(
     if not doc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail="Documentation not found.")
-    return GetFileDocsResponse(**doc)
+    return GetFileDocsResponse(**doc.model_dump())
 
 
 @router.delete("/file-docs/{doc_id}")

--- a/routers/docs.py
+++ b/routers/docs.py
@@ -25,7 +25,7 @@ async def generate_file_docs(
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail="Required field 'github_url' is missing.")
 
-    github_file = github_service.get_file(request.github_url)
+    github_file = github_service.get_file_from_url(request.github_url)
     doc_id = documentation_service.enqueue_generate_doc_job(
         background_tasks,
         github_file,

--- a/routers/repos.py
+++ b/routers/repos.py
@@ -2,9 +2,12 @@ from typing import Dict, Any, List
 
 from fastapi import APIRouter, Depends
 
-from schemas.documentation_generation import GetRepoResponse, GetReposResponse, RepoFormatted, ReposResponseModel
+from schemas.documentation_generation import GetRepoResponse, GetReposResponse, RepoFormatted, ReposResponseModel, \
+    CreateRepoDocsRequest, CreateRepoDocsResponse
 from services.documentation_service import DocumentationService, get_documentation_service
 from routers.utils.auth import get_user_token
+from services.github_service import GithubService, get_github_service
+from services.identifier_service import IdentifierService, get_identifier_service
 
 router = APIRouter()
 
@@ -30,3 +33,20 @@ async def get_repo(
     repo: RepoFormatted = documentation_service.get_repo(repo_id)
 
     return GetRepoResponse(repo=repo)
+
+
+@router.post("/repos")
+async def create_repo_docs(
+        request: CreateRepoDocsRequest,
+        identifier_service: IdentifierService = Depends(get_identifier_service),
+        github_service: GithubService = Depends(get_github_service),
+        user: Dict[str, Any] = Depends(get_user_token),
+) -> CreateRepoDocsResponse:
+    repo = github_service.get_repo_from_url(request.github_url)
+    repo_id = identifier_service.identify(repo)
+
+    return CreateRepoDocsResponse(
+        message="Documentation generation has been started.",
+        id=repo_id
+    )
+

--- a/routers/repos.py
+++ b/routers/repos.py
@@ -1,12 +1,13 @@
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 from fastapi import APIRouter, Depends
 
-from schemas.documentation_generation import GetRepoResponse, GetReposResponse
+from schemas.documentation_generation import GetRepoResponse, GetReposResponse, RepoFormatted, ReposResponseModel
 from services.documentation_service import DocumentationService, get_documentation_service
 from routers.utils.auth import get_user_token
 
 router = APIRouter()
+
 
 # for now returns all repos ids, no users yet
 @router.get("/repos")
@@ -14,9 +15,10 @@ async def get_repos(
         documentation_service: DocumentationService = Depends(get_documentation_service),
         user: Dict[str, Any] = Depends(get_user_token),
 ) -> GetReposResponse:
-    repos = documentation_service.get_repos()
+    repos: List[ReposResponseModel] = documentation_service.get_repos()
 
     return GetReposResponse(repos=repos)
+
 
 # for now returns all repos
 @router.get("/repos/{repo_id}")
@@ -25,6 +27,6 @@ async def get_repo(
         documentation_service: DocumentationService = Depends(get_documentation_service),
         user: Dict[str, Any] = Depends(get_user_token),
 ) -> GetRepoResponse:
-    repo = documentation_service.get_repo(repo_id)
-    
+    repo: RepoFormatted = documentation_service.get_repo(repo_id)
+
     return GetRepoResponse(repo=repo)

--- a/routers/repos.py
+++ b/routers/repos.py
@@ -42,11 +42,11 @@ async def create_repo_docs(
         github_service: GithubService = Depends(get_github_service),
         user: Dict[str, Any] = Depends(get_user_token),
 ) -> CreateRepoDocsResponse:
-    repo = github_service.get_repo_from_url(request.github_url)
-    repo_id = identifier_service.identify(repo)
+    github_repo = github_service.get_repo_from_url(request.github_url)
+    firestore_repo = identifier_service.identify(github_repo)
 
     return CreateRepoDocsResponse(
         message="Documentation generation has been started.",
-        id=repo_id
+        id=firestore_repo.id
     )
 

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -13,14 +13,16 @@ class LlmModelEnum(str, Enum):
     LLAMA_7B = 'meta-llama/Llama-2-7b-chat-hf'
 
 
-class DocsStatusEnum(str, Enum):
-    STARTED = 'STARTED'
+class DocStatusEnum(str, Enum):
+    NOT_STARTED = 'NOT STARTED'
+    IN_PROGRESS = 'IN PROGRESS'
     COMPLETED = 'COMPLETED'
+    FAILED = 'FAILED'
 
 
-class RepoNodeType(str, Enum):
-    FILE = 'FILE'
-    FOLDER = 'FOLDER'
+class FirestoreDocType(str, Enum):
+    FILE = 'file'
+    DIRECTORY = 'dir'
 
 
 class GeneratedDoc(BaseModel):
@@ -31,31 +33,24 @@ class GeneratedDoc(BaseModel):
 
 
 class FirestoreDoc(BaseModel):
+    id: Optional[str] = None
     github_url: Optional[str] = None
     relative_path: Optional[str] = None
-    type: Optional[str] = None
+    type: Optional[FirestoreDocType] = None
     size: Optional[int] = None
     extracted_data: Optional[Dict[str, Any]] = None
     markdown_content: Optional[str] = None
     usage: Optional[CompletionUsage] = None
-    status: Optional[DocsStatusEnum] = None
+    status: Optional[DocStatusEnum] = None
 
 
-class FirestoreRepoDocModel(BaseModel):
-    id: str
-    name: str
-    path: str
-    status: DocsStatusEnum
-    type: RepoNodeType
-
-
-class FirestoreRepoCreateModel(BaseModel):
-    dependencies: dict[str, str]
-    root_doc: FirestoreRepoDocModel  # {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}
-    docs: list[
-        FirestoreRepoDocModel]  # [{id: "doc_id_1", path: "/README.md", status: "COMPLETED"}, {id: "doc_id_2", path: "/README2.md", status: "STARTED"}]
-    version: str  # commitId
-    repo_name: str
+class FirestoreRepo(BaseModel):
+    id: Optional[str] = None
+    dependencies: Optional[Dict[str, str | None]] = None
+    root_doc: Optional[FirestoreDoc] = None  # {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}
+    docs: Optional[List[FirestoreDoc]] = None  # [{id: "doc_id_1", path: "/README.md", status: "COMPLETED"}, {id: "doc_id_2", path: "/README2.md", status: "STARTED"}]
+    version: Optional[str] = None  # commitId
+    repo_name: Optional[str] = None
 
 
 # POST /file-docs
@@ -74,7 +69,7 @@ class GenerateFileDocsResponse(BaseModel):
 class GetFileDocsResponse(BaseModel):
     id: str
     github_url: str
-    status: str
+    status: DocStatusEnum
     relative_path: str
     markdown_content: str | None
 
@@ -104,9 +99,9 @@ class LlmDocSchema(BaseModel):
 
 class RepoNode(BaseModel):
     id: str
-    name: str
-    type: RepoNodeType
-    completion_status: DocsStatusEnum
+    path: str
+    type: FirestoreDocType
+    completion_status: DocStatusEnum
     children: list['RepoNode'] = []
 
 
@@ -117,20 +112,35 @@ class RepoFormatted(BaseModel):
     nodes_map: dict[str, RepoNode] = Field(exclude=True)  # id to RepoNode
 
     def insert_node(self,
-                    parent: FirestoreRepoDocModel,
-                    child: FirestoreRepoDocModel,
-                    ) -> RepoNode:
+                    parent: FirestoreDoc,
+                    child: FirestoreDoc,
+                    ) -> None:
         if parent.id in self.nodes_map.keys():
-            child_node = RepoNode(id=child.id, name=child.name, type=child.type, completion_status=child.status,
-                                  children=[])  # place holder type and status
+            child_node = RepoNode(
+                id=child.id,
+                path=child.relative_path,
+                type=child.type,
+                completion_status=child.status,
+                children=[]
+            )  # place holder type and status
             self.nodes_map[parent.id].children.append(child_node)
             self.nodes_map[child.id] = child_node
         else:
             # should only happen for root
-            child_node = RepoNode(id=child.id, name=child.name, type=child.type, completion_status=child.status,
-                                  children=[])  # place holder type and status
-            parent_node = RepoNode(id=parent.id, name=parent.name, type=parent.type, completion_status=parent.status,
-                                   children=[child_node])  # place holder type and status
+            child_node = RepoNode(
+                id=child.id,
+                path=child.relative_path,
+                type=child.type,
+                completion_status=child.status,
+                children=[]
+            )  # place holder type and status
+            parent_node = RepoNode(
+                id=parent.id,
+                path=parent.relative_path,
+                type=parent.type,
+                completion_status=parent.status,
+                children=[child_node]
+            )  # place holder type and status
             self.nodes_map[parent.id] = parent_node
             self.nodes_map[child.id] = child_node
             self.tree.append(parent_node)
@@ -152,10 +162,6 @@ class RepoFormatted(BaseModel):
 
 # GET /repos/{repo_id}
 
-class RepoResponseModel(FirestoreRepoCreateModel):
-    id: str
-
-
 class GetRepoResponse(BaseModel):
     repo: RepoFormatted
 
@@ -165,8 +171,8 @@ class GetRepoResponse(BaseModel):
 class ReposResponseModel(BaseModel):
     name: str
     id: str
-    status: list[dict[str, DocsStatusEnum]]
+    status: List[Dict[str, DocStatusEnum]]
 
 
 class GetReposResponse(BaseModel):
-    repos: list[ReposResponseModel]
+    repos: List[ReposResponseModel]

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -5,12 +5,13 @@ import firebase_admin
 from dotenv import load_dotenv
 from fastapi import HTTPException, status
 from firebase_admin import storage, firestore
-from google.cloud.firestore_v1 import DocumentReference
+from google.cloud.firestore_v1 import DocumentReference, WriteBatch
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
 from google.cloud.firestore_v1.client import Client
 from google.cloud.storage import Blob
+from pydantic import BaseModel
 
-from schemas.documentation_generation import DocsStatusEnum
+from schemas.documentation_generation import DocStatusEnum
 
 
 class DataService:
@@ -40,6 +41,13 @@ class DataService:
 
         return document_ref.id
 
+    def batch_add_documentation(self, data) -> List[DocumentReference]:
+        result = self._batch_add(
+            self.DOCUMENTATION_COLLECTION,
+            data
+        )
+        return result
+
     def update_documentation(self, doc_id: str, data) -> None:
         self._update(
             self.DOCUMENTATION_COLLECTION,
@@ -49,13 +57,24 @@ class DataService:
 
     def delete_documentation(self, doc_id: str) -> None:
         doc = self._get(self.DOCUMENTATION_COLLECTION, doc_id)
-        if doc.get("status") == DocsStatusEnum.STARTED:
+        if doc.get("status") == DocStatusEnum.IN_PROGRESS:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Data is still being generated for this id, so it cannot be deleted yet.")
         self._delete(
             self.DOCUMENTATION_COLLECTION,
             doc_id
         )
+
+    def add_repo(self, data) -> str:
+        document_ref = self._add(
+            self.REPO_COLLECTION,
+            data
+        )
+        return document_ref.id
+
+    def batch_create_repo(self, repo, docs) -> None:
+        self._batch_set(self.REPO_COLLECTION, repo)
+        self._batch_set(self.DOCUMENTATION_COLLECTION, docs)
 
     def get_repo(self, repo_id) -> Dict[str, Any]:
         repo = self._get(self.REPO_COLLECTION, repo_id)
@@ -68,8 +87,34 @@ class DataService:
 
     def _add(self, collection_path, data) -> DocumentReference:
         collection_ref = self.db.collection(collection_path)
+        if isinstance(data, BaseModel):
+            data = data.model_dump()
         update_time, document_ref = collection_ref.add(data)
         return document_ref
+
+    def _batch_add(self, collection_path, data) -> List[DocumentReference]:
+        collection_ref = self.db.collection(collection_path)
+        batch = self.db.batch()
+        if not isinstance(data, list):
+            data = [data]
+        for doc in data:
+            if isinstance(doc, BaseModel):
+                doc = doc.model_dump(exclude_unset=True)
+            batch.set(collection_ref.document(), doc)
+        result = batch.commit()
+        return result
+
+    def _batch_set(self, collection_path, data) -> List[DocumentReference]:
+        collection_ref = self.db.collection(collection_path)
+        batch = self.db.batch()
+        if not isinstance(data, list):
+            data = [data]
+        for doc in data:
+            if isinstance(doc, BaseModel):
+                doc = doc.model_dump(exclude_unset=True)
+            batch.set(collection_ref.document(doc.get("id")), doc)
+        result = batch.commit()
+        return result
 
     def _get(self, collection_path, document_id) -> DocumentSnapshot | None:
         document_ref = self.db.collection(collection_path).document(document_id)
@@ -80,6 +125,8 @@ class DataService:
 
     def _update(self, collection_path, document_id, data) -> None:
         document_ref = self.db.collection(collection_path).document(document_id)
+        if isinstance(data, BaseModel):
+            data = data.model_dump()
         document_ref.update(data)
 
     def _delete(self, collection_path, document_id) -> None:

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -28,7 +28,8 @@ class DataService:
         if not document_snapshot:
             return None
         document_dict = document_snapshot.to_dict()
-        firestore_doc = FirestoreDoc(**document_dict, id=document_snapshot.id)
+        document_dict["id"] = document_snapshot.id
+        firestore_doc = FirestoreDoc(**document_dict)
         return firestore_doc
 
     def add_documentation(self, data) -> str:

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -28,7 +28,6 @@ class DataService:
         if not document_snapshot:
             return None
         document_dict = document_snapshot.to_dict()
-        # document_dict["id"] = document_snapshot.id
         firestore_doc = FirestoreDoc(**document_dict, id=document_snapshot.id)
         return firestore_doc
 

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -194,7 +194,7 @@ class DocumentationService:
     
     @staticmethod
     def _format_repo(repo_response: FirestoreRepo) -> RepoFormatted:
-        root_doc: FirestoreDoc = repo_response.root_doc
+        root_doc: str = repo_response.root_doc
         repo_name: str = repo_response.repo_name
         repo_id: str = repo_response.id
         dependencies: dict[str, str] = repo_response.dependencies
@@ -230,7 +230,7 @@ class DocumentationService:
                         queue.append(child)
                         used.add(child)
 
-        bfs(root_doc.id)
+        bfs(root_doc)
 
         return repo_formatted
 

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -8,9 +8,9 @@ import firebase_admin
 from github.ContentFile import ContentFile
 from openai.types.chat import ChatCompletion
 
-from schemas.documentation_generation import DocsStatusEnum, \
-    RepoResponseModel, GeneratedDoc, LlmModelEnum, LlmDocSchema, RepoFormatted, \
-    FirestoreRepoDocModel, ReposResponseModel, FirestoreDoc
+from schemas.documentation_generation import DocStatusEnum, \
+    GeneratedDoc, LlmModelEnum, LlmDocSchema, RepoFormatted, \
+    ReposResponseModel, FirestoreDoc, FirestoreRepo
 from services.clients.anyscale_client import get_anyscale_client
 from services.data_service import DataService, get_data_service
 from fastapi import BackgroundTasks, HTTPException, status
@@ -68,7 +68,7 @@ class DocumentationService:
                 extracted_data=generated_doc.extracted_data,
                 markdown_content=generated_doc.markdown_content,
                 usage=generated_doc.usage,
-                status=DocsStatusEnum.COMPLETED,
+                status=DocStatusEnum.COMPLETED,
             ).model_dump(exclude_defaults=True)
         )
 
@@ -84,7 +84,7 @@ class DocumentationService:
                 type=file.type,
                 size=file.size,
                 relative_path=file.path,
-                status=DocsStatusEnum.STARTED
+                status=DocStatusEnum.IN_PROGRESS
             ).model_dump()
         )
 
@@ -107,11 +107,11 @@ class DocumentationService:
         doc = self.data_service.get_documentation(doc_id)
         firestore_doc = FirestoreDoc(**doc)
 
-        if firestore_doc.status == DocsStatusEnum.STARTED:
+        if firestore_doc.status not in [DocStatusEnum.COMPLETED, DocStatusEnum.FAILED]:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Data is still being generated for this id, so it cannot be regenerated yet.")
 
-        github_file = self.github_service.get_file(firestore_doc.github_url)
+        github_file = self.github_service.get_file_from_url(firestore_doc.github_url)
 
         self.data_service.update_documentation(
             doc_id,
@@ -120,7 +120,7 @@ class DocumentationService:
                 type=github_file.type,
                 size=github_file.size,
                 relative_path=github_file.path,
-                status=DocsStatusEnum.STARTED
+                status=DocStatusEnum.IN_PROGRESS
             ).model_dump()
         )
 
@@ -133,9 +133,9 @@ class DocumentationService:
 
         return doc_id
 
-    def get_repos(self) -> list[ReposResponseModel]:
+    def get_repos(self) -> List[ReposResponseModel]:
         repos_dicts = self.data_service.get_repos()
-        repos = [RepoResponseModel.model_validate(repo_dict) for repo_dict in repos_dicts]
+        repos = [FirestoreRepo(**repo_dict) for repo_dict in repos_dicts]
         repos_formatted = [ReposResponseModel(name=repo.repo_name, id=repo.id, status=self._get_repo_status(repo)) for
                            repo in repos]
 
@@ -143,7 +143,7 @@ class DocumentationService:
 
     def get_repo(self, repo_id) -> RepoFormatted:
         repo_dict = self.data_service.get_repo(repo_id)
-        repo = RepoResponseModel.model_validate(repo_dict)
+        repo = FirestoreRepo(**repo_dict)
         repo_formatted = self._format_repo(repo)
         return repo_formatted
 
@@ -193,24 +193,24 @@ class DocumentationService:
                                 detail="LLM output not parsable")
     
     @staticmethod
-    def _format_repo(repo_response: RepoResponseModel) -> RepoFormatted:
-        root_doc: FirestoreRepoDocModel = repo_response.root_doc
+    def _format_repo(repo_response: FirestoreRepo) -> RepoFormatted:
+        root_doc: FirestoreDoc = repo_response.root_doc
         repo_name: str = repo_response.repo_name
         repo_id: str = repo_response.id
         dependencies: dict[str, str] = repo_response.dependencies
-        docs: list[FirestoreRepoDocModel] = repo_response.docs
+        docs: list[FirestoreDoc] = repo_response.docs
 
         repo_formatted = RepoFormatted(name=repo_name, id=repo_id, tree=[], nodes_map={})
 
-        def find_doc_by_id(doc_list: list[FirestoreRepoDocModel], doc_id) -> FirestoreRepoDocModel | None:
+        def find_doc_by_id(doc_list: list[FirestoreDoc], doc_id) -> FirestoreDoc | None:
             for doc in doc_list:
                 if doc.id == doc_id:
                     return doc
             return None
 
         def process_node(parent_id, child_id):
-            parent_data: FirestoreRepoDocModel = find_doc_by_id(docs, parent_id) 
-            child_data: FirestoreRepoDocModel = find_doc_by_id(docs, child_id) 
+            parent_data: FirestoreDoc = find_doc_by_id(docs, parent_id)
+            child_data: FirestoreDoc = find_doc_by_id(docs, child_id)
 
             repo_formatted.insert_node(parent_data, child_data)
        
@@ -235,7 +235,7 @@ class DocumentationService:
         return repo_formatted
 
     @staticmethod
-    def _get_repo_status(repo_response: RepoResponseModel) -> list[dict[str, DocsStatusEnum]]:
+    def _get_repo_status(repo_response: FirestoreRepo) -> list[dict[str, DocStatusEnum]]:
         docs = repo_response.docs
 
         repo_status = [{doc.id: doc.status} for doc in docs]

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -1,7 +1,9 @@
 import os
+import re
+import sys
 from urllib.parse import urlparse
 
-from typing import Optional
+from typing import Optional, List
 
 from dotenv import load_dotenv
 from fastapi import HTTPException, status
@@ -18,27 +20,58 @@ class GithubService:
             self.auth = Auth.Token(token)
         self.github = Github(auth=self.auth)
 
-    def get_file(self, github_url: str) -> ContentFile:
-        username, repo_name, file_path = self._extract_github_info(github_url)
+    def get_file_from_url(self, github_url: str) -> ContentFile:
+        owner, repo_name, file_path = self._extract_github_url_info(github_url)
+        if not file_path:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Invalid GitHub url")
 
-        repo: Repository = self.github.get_repo(username + "/" + repo_name)
+        repo: Repository = self.github.get_repo(owner + "/" + repo_name)
         contents: ContentFile = repo.get_contents(file_path)
         return contents
 
-    @staticmethod
-    def _extract_github_info(github_url):
-        url_parts = urlparse(github_url)
-        path_parts = url_parts.path.strip('/').split('/')
+    def get_repo_from_url(self, github_url: str) -> Repository:
+        username, repo_name, _ = self._extract_github_url_info(github_url)
+        return self.github.get_repo(username + "/" + repo_name)
 
+    @staticmethod
+    def get_repo_contents(repository: Repository, exclude: Optional[List[str]] = None) -> List[ContentFile]:
+        all_content = []
+        queue = repository.get_contents("")
+        while queue:
+            file_content = queue.pop(0)
+
+            if exclude:
+                if any(re.search(pattern, file_content.name) for pattern in exclude):
+                    continue
+
+            if file_content.type == "dir":
+                queue.extend(repository.get_contents(file_content.path))
+            all_content.append(file_content)
+
+        return all_content
+
+    @staticmethod
+    def _extract_github_url_info(github_url):
+        url_parts = urlparse(github_url)
+        if url_parts.netloc != "github.com":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Invalid GitHub url")
+
+        path_parts = url_parts.path.strip('/').split('/')
         if len(path_parts) < 2:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail="Invalid GitHub url")
 
-        username = path_parts[0]
+        owner = path_parts[0]
         repository_name = path_parts[1]
-        file_path = '/'.join(path_parts[4:])
 
-        return username, repository_name, file_path
+        if len(path_parts) >= 4 and path_parts[2] == "blob":
+            file_path = '/'.join(path_parts[4:])
+        else:
+            file_path = None
+
+        return owner, repository_name, file_path
 
 
 def get_github_service():
@@ -49,5 +82,25 @@ def get_github_service():
 if __name__ == "__main__":
     load_dotenv()
     github = get_github_service()
-    content = github.get_file("https://github.com/carlos-jmh/miniDiscord/blob/main/chat/storage.go")
-    print(content)
+
+    # content = github.get_file_from_url(
+    #     "https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py"
+    # )
+    # print(content)
+
+    # repo = github.get_repo_from_url("https://github.com/KTujjar/rocketdocs/tree/main")
+    # contents = github.get_repo_contents(
+    #     repo,
+    #     exclude=[
+    #         ".gitignore",
+    #         ".dockerignore",
+    #         ".env",
+    #         "clients",
+    #         "__init__.py",
+    #         "Dockerfile",
+    #         "README.md",
+    #         "LICENSE",
+    #         "requirements.txt"
+    #     ]
+    # )
+    # print(contents)

--- a/services/github_service.py
+++ b/services/github_service.py
@@ -35,7 +35,7 @@ class GithubService:
         return self.github.get_repo(username + "/" + repo_name)
 
     @staticmethod
-    def get_repo_contents(repository: Repository, exclude: Optional[List[str]] = None) -> List[ContentFile]:
+    def get_all_repo_contents(repository: Repository, exclude: Optional[List[str]] = None) -> List[ContentFile]:
         all_content = []
         queue = repository.get_contents("")
         while queue:

--- a/services/identifier_service.py
+++ b/services/identifier_service.py
@@ -16,9 +16,7 @@ from services.github_service import GithubService, get_github_service
 
 
 class IdentifierService:
-    def __init__(self, llm_client: LLMClient, github_service: GithubService, data_service: DataService):
-        self.llm_client = llm_client
-        self.github_service = github_service
+    def __init__(self, data_service: DataService):
         self.data_service = data_service
         self.exclude_files = [
             re.compile(pattern) for pattern in [
@@ -33,7 +31,7 @@ class IdentifierService:
             ]
         ]
 
-    def identify(self, repository: Repository):
+    def identify(self, repository: Repository) -> str:
         root = FirestoreDoc(
             id=str(uuid.uuid4()),
             github_url=repository.html_url,
@@ -74,17 +72,15 @@ class IdentifierService:
             dependencies=dependencies,
             docs=docs,
             repo_name=repository.full_name,
-            root_doc=root
+            root_doc=root.id
         )
-        self.data_service.batch_create_repo(repo, repo.docs)
+        repo_id = self.data_service.batch_create_repo(repo)
+        return repo_id
 
 
 def get_identifier_service() -> IdentifierService:
-    """Initializes the service with any dependencies it needs."""
-    llm_client = get_anyscale_client()
-    github_service = get_github_service()
     data_service = get_data_service()
-    return IdentifierService(llm_client, github_service, data_service)
+    return IdentifierService(data_service)
 
 
 # For manually testing this file

--- a/services/identifier_service.py
+++ b/services/identifier_service.py
@@ -31,7 +31,7 @@ class IdentifierService:
             ]
         ]
 
-    def identify(self, repository: Repository) -> str:
+    def identify(self, repository: Repository) -> FirestoreRepo:
         root = FirestoreDoc(
             id=str(uuid.uuid4()),
             github_url=repository.html_url,
@@ -74,8 +74,8 @@ class IdentifierService:
             repo_name=repository.full_name,
             root_doc=root.id
         )
-        repo_id = self.data_service.batch_create_repo(repo)
-        return repo_id
+        self.data_service.batch_create_repo(repo)
+        return repo
 
 
 def get_identifier_service() -> IdentifierService:

--- a/services/identifier_service.py
+++ b/services/identifier_service.py
@@ -1,0 +1,102 @@
+import os
+import re
+import uuid
+
+import firebase_admin
+from github.Repository import Repository
+
+from schemas.documentation_generation import FirestoreRepo, FirestoreDoc, DocStatusEnum
+from services.clients.anyscale_client import get_anyscale_client
+from services.data_service import DataService, get_data_service
+
+from dotenv import load_dotenv
+
+from services.clients.llm_client import LLMClient
+from services.github_service import GithubService, get_github_service
+
+
+class IdentifierService:
+    def __init__(self, llm_client: LLMClient, github_service: GithubService, data_service: DataService):
+        self.llm_client = llm_client
+        self.github_service = github_service
+        self.data_service = data_service
+        self.exclude_files = [
+            re.compile(pattern) for pattern in [
+                "README.md",
+                ".gitignore",
+                ".dockerignore",
+                "__init__.py",
+                "Dockerfile",
+                "LICENSE",
+                "requirements.txt",
+                "test"
+            ]
+        ]
+
+    def identify(self, repository: Repository):
+        root = FirestoreDoc(
+            id=str(uuid.uuid4()),
+            github_url=repository.html_url,
+            relative_path="",
+            type="dir",
+            status=DocStatusEnum.NOT_STARTED
+        )
+
+        docs = [root]
+        dependencies = {root.id: None}
+
+        queue = [root]
+        while queue:
+            parent = queue.pop(0)
+            contents = repository.get_contents(parent.relative_path)
+
+            for content in contents:
+                if any(pattern.match(content.name) for pattern in self.exclude_files):
+                    continue
+
+                firestore_doc = FirestoreDoc(
+                    id=str(uuid.uuid4()),
+                    github_url=content.html_url,
+                    relative_path=content.path,
+                    type=content.type,
+                    size=content.size or None,
+                    status=DocStatusEnum.NOT_STARTED
+                )
+                docs.append(firestore_doc)
+
+                if content.type == "dir":
+                    queue.append(firestore_doc)
+
+                dependencies[firestore_doc.id] = parent.id
+
+        repo = FirestoreRepo(
+            id=str(uuid.uuid4()),
+            dependencies=dependencies,
+            docs=docs,
+            repo_name=repository.full_name,
+            root_doc=root
+        )
+        self.data_service.batch_create_repo(repo, repo.docs)
+
+
+def get_identifier_service() -> IdentifierService:
+    """Initializes the service with any dependencies it needs."""
+    llm_client = get_anyscale_client()
+    github_service = get_github_service()
+    data_service = get_data_service()
+    return IdentifierService(llm_client, github_service, data_service)
+
+
+# For manually testing this file
+if __name__ == "__main__":
+    load_dotenv()
+    firebase_app = firebase_admin.initialize_app(
+        credential=None,
+        options={"storageBucket": os.getenv("CLOUD_STORAGE_BUCKET")}
+    )
+
+    github = get_github_service()
+    identifier = get_identifier_service()
+
+    test_repo = github.get_repo_from_url("https://github.com/KTujjar/rocketdocs")
+    identifier.identify(test_repo)


### PR DESCRIPTION
- some small reworks like adding new `DocStatusEnum` fields and slightly changing the repo fields.

- Added an `IdentifierService` which runs through basic heuristic to identify which files we should document. Currently just using RegEx.
- Added some batch-write operations so we can create the new repo and docs in a single Firestore api call, instead of many.
  - This means we are manually setting the id of the new documents. Due to the weird way Firestore deals with ids, I am also purposefully setting a new `id` field which contains the id. This made it easier to work with our Pydantic models. Not opposed to doing this on all our other operations/models too.