### PR TITLE
Repo Generation Heuristic (basic)

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import firebase_admin
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routers import docs, repos
+from routers import file_docs, repos
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -30,7 +30,7 @@ app.add_middleware(
 )
 
 # Include Routers
-app.include_router(docs.router)
+app.include_router(file_docs.router)
 app.include_router(repos.router)
 
 # Initializing Firebase App

--- a/routers/file_docs.py
+++ b/routers/file_docs.py
@@ -29,7 +29,7 @@ async def generate_file_docs(
 
     github_file = github_service.get_file_from_url(request.github_url)
 
-    doc_id = documentation_service.enqueue_generate_doc_job(
+    doc_id = documentation_service.enqueue_generate_file_doc_job(
         user_id,
         background_tasks,
         github_file,

--- a/routers/repos.py
+++ b/routers/repos.py
@@ -1,9 +1,10 @@
 from typing import Dict, Any, List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, BackgroundTasks, HTTPException
+from starlette import status
 
-from schemas.documentation_generation import GetRepoResponse, GetReposResponse, RepoFormatted, ReposResponseModel, \
-    CreateRepoDocsRequest, CreateRepoDocsResponse, FirestoreRepo
+from schemas.documentation_generation import GetRepoResponse, GetReposResponse, ReposResponseModel, \
+    CreateRepoDocsRequest, CreateRepoDocsResponse, FirestoreRepo, LlmModelEnum, GetFileDocsResponse
 from services.documentation_service import DocumentationService, get_documentation_service
 from routers.utils.auth import get_user_token
 from services.github_service import GithubService, get_github_service
@@ -23,12 +24,18 @@ async def get_repos(
 
     repos_dicts = data_service.get_user_repos(user_id)
     repos = [FirestoreRepo(**repo_dict) for repo_dict in repos_dicts]
-    repos_formatted = [ReposResponseModel(name=repo.repo_name, id=repo.id, status= DocumentationService.get_repo_status(repo)) for repo in repos]
+    repos_formatted = [
+        ReposResponseModel(
+            name=repo.repo_name,
+            id=repo.id,
+            status=DocumentationService.get_repo_status(repo)
+        )
+        for repo in repos
+    ]
     
     return GetReposResponse(repos=repos_formatted)
 
 
-# for now returns all repos
 @router.get("/repos/{repo_id}")
 async def get_repo(
         repo_id: str,
@@ -44,15 +51,40 @@ async def get_repo(
     return GetRepoResponse(repo=repo_formatted)
 
 
+@router.get("/repos/{repo_id}/{doc_id}")
+async def get_repo_doc(
+        repo_id: str,
+        doc_id: str,
+        data_service: DataService = Depends(get_data_service),
+        user: Dict[str, Any] = Depends(get_user_token),
+) -> GetFileDocsResponse:
+    user_id = user.get("uid")
+    doc = data_service.get_user_documentation(user_id, doc_id)
+
+    if doc.repo != repo_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Document does not belong to the repo")
+
+    return GetFileDocsResponse(**doc.model_dump())
+
+
 @router.post("/repos")
 async def create_repo_docs(
         request: CreateRepoDocsRequest,
+        background_tasks: BackgroundTasks,
         identifier_service: IdentifierService = Depends(get_identifier_service),
         github_service: GithubService = Depends(get_github_service),
+        documentation_service: DocumentationService = Depends(get_documentation_service),
         user: Dict[str, Any] = Depends(get_user_token),
+        model: LlmModelEnum = LlmModelEnum.MIXTRAL
 ) -> CreateRepoDocsResponse:
+    user_id = user.get("uid")
     github_repo = github_service.get_repo_from_url(request.github_url)
-    firestore_repo = identifier_service.identify(github_repo)
+    firestore_repo = identifier_service.identify(github_repo, user_id)
+    documentation_service.enqueue_generate_repo_docs_job(
+        background_tasks,
+        firestore_repo,
+        model
+    )
 
     return CreateRepoDocsResponse(
         message="Documentation generation has been started.",

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -24,7 +24,7 @@ class GeneratedDoc(BaseModel):
 
 # Firestore Models
 
-class DocStatusEnum(str, Enum):
+class StatusEnum(str, Enum):
     NOT_STARTED = 'NOT STARTED'
     IN_PROGRESS = 'IN PROGRESS'
     COMPLETED = 'COMPLETED'
@@ -45,17 +45,20 @@ class FirestoreDoc(BaseModel):
     extracted_data: Optional[Dict[str, Any]] = None
     markdown_content: Optional[str] = None
     usage: Optional[CompletionUsage] = None
-    status: Optional[DocStatusEnum] = None
+    status: Optional[StatusEnum] = None
+    repo: Optional[str] = None
     owner: Optional[str] = None
 
 
 class FirestoreRepo(BaseModel):
     id: Optional[str] = None
     dependencies: Optional[Dict[str, str | None]] = None
-    root_doc: Optional[str] = None  # {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}
-    docs: Optional[List[FirestoreDoc]] = None  # [{id: "doc_id_1", path: "/README.md", status: "COMPLETED"}, {id: "doc_id_2", path: "/README2.md", status: "STARTED"}]
+    root_doc: Optional[str] = None
+    docs: Optional[
+        Dict[str, FirestoreDoc]] = None  # {doc_id_1: {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}}
     version: Optional[str] = None  # commitId
     repo_name: Optional[str] = None
+    status: Optional[StatusEnum] = None
     owner: Optional[str] = None
 
 
@@ -63,6 +66,7 @@ class FirestoreBatchOpType(str, Enum):
     SET = 'SET'
     UPDATE = 'UPDATE'
     DELETE = 'DELETE'
+
 
 class FirestoreQuery(BaseModel):
     OP_STRING_EQUALS: ClassVar[str] = '=='
@@ -95,7 +99,7 @@ class GenerateFileDocsResponse(BaseModel):
 class GetFileDocsResponse(BaseModel):
     id: str
     github_url: str
-    status: DocStatusEnum
+    status: StatusEnum
     relative_path: str
     markdown_content: str | None
 
@@ -116,9 +120,13 @@ class UpdateFileDocsResponse(BaseModel):
 
 # LLM Generation Models
 
-class LlmDocSchema(BaseModel):
-    description: str = Field("Around 100 words about the code's purpose")
-    dependencies: List[str] = Field("Outside dependencies the code uses")
+class LlmFileDocSchema(BaseModel):
+    description: str = Field("Around 100 words about the code's purpose. Remember to be concise.")
+    # dependencies: List[str] = Field("Outside dependencies the code uses")
+
+
+class LlmFolderDocSchema(BaseModel):
+    description: str = Field("Around 100 words about the overall purpose. Remember to be concise.")
 
 
 # repo tree
@@ -127,7 +135,7 @@ class RepoNode(BaseModel):
     id: str
     path: str
     type: FirestoreDocType
-    completion_status: DocStatusEnum
+    completion_status: StatusEnum
     children: list['RepoNode'] = []
 
 
@@ -198,7 +206,7 @@ class GetRepoResponse(BaseModel):
 class ReposResponseModel(BaseModel):
     name: str
     id: str
-    status: List[Dict[str, DocStatusEnum]]
+    status: List[Dict[str, StatusEnum]]
 
 
 class GetReposResponse(BaseModel):

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -1,16 +1,17 @@
 import asyncio
 import json
 import os
-from typing import Coroutine, List, Any, Dict
-from collections import deque
+from typing import Coroutine, List, Any, Dict, Optional, Type
+from collections import deque, defaultdict
 
 import firebase_admin
 from github.ContentFile import ContentFile
 from openai.types.chat import ChatCompletion
+from pydantic import BaseModel
 
-from schemas.documentation_generation import DocStatusEnum, \
-    GeneratedDoc, LlmModelEnum, LlmDocSchema, RepoFormatted, \
-    ReposResponseModel, FirestoreDoc, FirestoreRepo
+from schemas.documentation_generation import StatusEnum, \
+    GeneratedDoc, LlmModelEnum, LlmFileDocSchema, RepoFormatted, \
+    FirestoreDoc, FirestoreRepo, FirestoreDocType, LlmFolderDocSchema
 from services.clients.anyscale_client import get_anyscale_client
 from services.data_service import DataService, get_data_service
 from fastapi import BackgroundTasks, HTTPException, status
@@ -26,41 +27,102 @@ class DocumentationService:
         self.llm_client = llm_client
         self.github_service = github_service
         self.data_service = data_service
-        self.system_prompt_for_file_json = ("You are a helpful assistant that generates "
-                                            "high-level documentation of code. Respond in JSON.")
+        self.system_prompt_for_file_json = ("Your job is to generate concise high-level documentation of a file, "
+                                            "based on its code. Respond in JSON.")
+        self.system_prompt_for_folder_json = ("Your job is to generate concise high-level documentation of a "
+                                              "folder, based on the description of its contents. Respond in JSON.")
+        self.system_prompt_for_markdown_content = ("Your job is to format received input into concise documentation. "
+                                                   "Respond in Markdown text.")
 
-    async def generate_doc_for_file(
+    async def _generate_doc_for_file(
             self,
             file: ContentFile,
             model: LlmModelEnum
     ) -> GeneratedDoc:
-        if not file:
+        if not file or file.type != FirestoreDocType.FILE:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail="File cannot be empty")
 
-        user_prompt = f"{file.path}:\n" + str(file.decoded_content)
-        llm_completion = await self._generate_doc_completion(model, user_prompt)
+        user_prompt = f"{file.path}:\n{file.decoded_content}\nRemember to respond in less than 100 words."
+        llm_completion = await self._generate_doc_completion(
+            model,
+            user_prompt,
+            self.system_prompt_for_file_json,
+            LlmFileDocSchema
+        )
         json_content = self._parse_and_validate_llm_completion(llm_completion)
 
         markdown_content = await self._generate_markdown_content(model, json_content)
 
-        response = GeneratedDoc(
+        return GeneratedDoc(
             relative_path=file.path,
             usage=llm_completion.usage,
             extracted_data=json_content,
             markdown_content=markdown_content
         )
 
-        return response
+    async def _generate_doc_for_folder(
+            self,
+            folder: FirestoreDoc,
+            files: List[FirestoreDoc],
+            model: LlmModelEnum
+    ) -> GeneratedDoc:
+        self._validate_folder_and_files(folder, files)
 
-    # background tasks for generating the documentation
-    def generate_doc_background_task(
+        user_prompt = (
+            "This is the root folder."
+            if not folder.relative_path
+            else f"This is the {folder.relative_path} folder."
+        )
+        user_prompt += f" It contains:\n" + "\n".join(
+            f"{file.relative_path}: {file.extracted_data.get('description')}" for file in files
+        )
+        user_prompt += "\nRemember to respond in less than 100 words."
+
+        llm_completion = await self._generate_doc_completion(
+            model,
+            user_prompt,
+            self.system_prompt_for_folder_json,
+            LlmFolderDocSchema
+        )
+        json_content = self._parse_and_validate_llm_completion(llm_completion)
+
+        markdown_content = await self._generate_markdown_content(model, json_content)
+
+        return GeneratedDoc(
+            relative_path=folder.relative_path,
+            usage=llm_completion.usage,
+            extracted_data=json_content,
+            markdown_content=markdown_content
+        )
+
+    async def generate_doc(
             self,
             doc_id: str,
-            file: ContentFile,
-            model: LlmModelEnum
-    ) -> None:
-        generated_doc = asyncio.run(self.generate_doc_for_file(file, model))
+            model: LlmModelEnum,
+            dependencies: Optional[List[str]] = None
+    ):
+        if dependencies is None:
+            dependencies = []
+
+        doc = self.data_service.get_documentation(doc_id)
+        dep_docs = [self.data_service.get_documentation(dep) for dep in dependencies]
+        self._validate_doc_and_dependencies(doc, dep_docs)
+
+        self.data_service.update_documentation(doc_id, FirestoreDoc(status=StatusEnum.IN_PROGRESS))
+
+        try:
+            if doc.type == FirestoreDocType.FILE:
+                file_content = self.github_service.get_file_from_url(doc.github_url)
+                generated_doc = await self._generate_doc_for_file(file_content, model)
+            elif doc.type == FirestoreDocType.DIRECTORY:
+                generated_doc = await self._generate_doc_for_folder(doc, dep_docs, model)
+            else:
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                    detail="Doc type not supported")
+        except Exception as e:
+            self.data_service.update_documentation(doc.id, FirestoreDoc(status=StatusEnum.FAILED))
+            raise e
 
         self.data_service.update_documentation(
             doc_id,
@@ -68,11 +130,29 @@ class DocumentationService:
                 extracted_data=generated_doc.extracted_data,
                 markdown_content=generated_doc.markdown_content,
                 usage=generated_doc.usage,
-                status=DocStatusEnum.COMPLETED,
-            ).model_dump(exclude_defaults=True)
+                status=StatusEnum.COMPLETED,
+            )
         )
 
-    def enqueue_generate_doc_job(
+    # background tasks for generating the documentation
+    def generate_file_doc_background_task(
+            self,
+            doc_id: str,
+            model: LlmModelEnum
+    ) -> None:
+        generated_doc = asyncio.run(self.generate_doc(doc_id, model))
+
+        self.data_service.update_documentation(
+            doc_id,
+            FirestoreDoc(
+                extracted_data=generated_doc.extracted_data,
+                markdown_content=generated_doc.markdown_content,
+                usage=generated_doc.usage,
+                status=StatusEnum.COMPLETED,
+            )
+        )
+
+    def enqueue_generate_file_doc_job(
             self,
             user_id: str,
             background_tasks: BackgroundTasks,
@@ -85,20 +165,73 @@ class DocumentationService:
                 type=file.type,
                 size=file.size,
                 relative_path=file.path,
-                status=DocStatusEnum.IN_PROGRESS,
+                status=StatusEnum.IN_PROGRESS,
                 owner=user_id
-            ).model_dump()
+            )
         )
 
         # add task to be done async
         background_tasks.add_task(
-            self.generate_doc_background_task,
+            self.generate_file_doc_background_task,
             doc_id,
-            file,
             model
         )
 
         return doc_id
+
+    # TODO: implement a retry and error system
+    async def generate_repo_docs_background_task(
+            self,
+            firestore_repo: FirestoreRepo,
+            model: LlmModelEnum
+    ) -> None:
+        self._validate_repo(firestore_repo)
+
+        dgraph = firestore_repo.dependencies
+        root = firestore_repo.root_doc
+
+        children_graph = {parent: [] for parent in dgraph.values()}
+        indegree = defaultdict(int, {node: 0 for node in dgraph})
+
+        for child, parent in dgraph.items():
+            if parent:
+                children_graph[parent].append(child)
+                indegree[parent] += 1
+
+        while root in indegree:
+            leaves = [node for node, degree in indegree.items() if degree == 0]
+            tasks = [
+                self.generate_doc(leaf, model, children_graph.get(leaf))
+                for leaf in leaves
+            ]
+
+            results = await self._run_concurrently(tasks, 30)
+            for result in results:
+                if isinstance(result, BaseException):
+                    self.data_service.update_repo(firestore_repo.id, FirestoreRepo(status=StatusEnum.FAILED))
+                    raise result
+
+            for leaf in leaves:
+                parent = dgraph[leaf]
+                if parent:
+                    indegree[parent] -= 1
+                indegree.pop(leaf)
+
+        self.data_service.update_repo(firestore_repo.id, FirestoreRepo(status=StatusEnum.COMPLETED))
+
+    def enqueue_generate_repo_docs_job(
+            self,
+            background_tasks: BackgroundTasks,
+            firestore_repo: FirestoreRepo,
+            model: LlmModelEnum
+    ):
+        self.data_service.update_repo(firestore_repo.id, FirestoreRepo(status=StatusEnum.IN_PROGRESS))
+
+        background_tasks.add_task(
+            self.generate_repo_docs_background_task,
+            firestore_repo,
+            model
+        )
 
     def regenerate_doc(
             self,
@@ -107,13 +240,12 @@ class DocumentationService:
             doc_id: str,
             model: LlmModelEnum
     ) -> str:
-        firestore_doc:FirestoreDoc = self.data_service.get_user_documentation(user_id, doc_id)
-
-        if firestore_doc.status not in [DocStatusEnum.COMPLETED, DocStatusEnum.FAILED]:
+        doc = self.data_service.get_documentation(doc_id)
+        if doc.status not in [StatusEnum.COMPLETED, StatusEnum.FAILED]:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Data is still being generated for this id, so it cannot be regenerated yet.")
 
-        github_file = self.github_service.get_file_from_url(firestore_doc.github_url)
+        github_file = self.github_service.get_file_from_url(doc.github_url)
 
         self.data_service.update_documentation(
             doc_id,
@@ -124,12 +256,12 @@ class DocumentationService:
                 type=github_file.type,
                 size=github_file.size,
                 relative_path=github_file.path,
-                status=DocStatusEnum.IN_PROGRESS
-            ).model_dump()
+                status=StatusEnum.IN_PROGRESS
+            )
         )
 
         background_tasks.add_task(
-            self.generate_doc_background_task,
+            self.generate_file_doc_background_task,
             doc_id,
             github_file,
             model
@@ -137,32 +269,36 @@ class DocumentationService:
 
         return doc_id
 
-    async def _generate_doc_completion(self, model: LlmModelEnum, prompt: str) -> ChatCompletion:
+    async def _generate_doc_completion(
+            self,
+            model: LlmModelEnum,
+            prompt: str,
+            system_prompt: str,
+            class_type: Type[BaseModel]
+    ) -> ChatCompletion:
         return await self.llm_client.generate_json(
             model=model,
             prompt=prompt,
-            system_prompt=self.system_prompt_for_file_json,
-            response_schema=LlmDocSchema.model_json_schema(),
+            system_prompt=system_prompt,
+            response_schema=class_type.model_json_schema(),
             max_tokens=2048
         )
 
     async def _generate_markdown_content(self, model: LlmModelEnum, json_content: dict) -> str:
         prompt = json.dumps(json_content)
-        system_prompt = "Your job is to format received input into neat documentation. Respond in Markdown text."
+        prompt += "\n Remember to be concise."
 
         markdown_llm_completion = await self.llm_client.generate_text(
             model=model,
             prompt=prompt,
-            system_prompt=system_prompt,
+            system_prompt=self.system_prompt_for_markdown_content,
             max_tokens=2048
         )
 
         markdown_text = markdown_llm_completion.choices[0].message.content
-
         # rough fix for the bug where the first character is a space, seems to be an Anyscale thing
         if markdown_text[0] == " ":
             return markdown_text[1:]
-
         return markdown_text
 
     def _parse_and_validate_llm_completion(self, llm_completion: ChatCompletion) -> Dict[str, Any]:
@@ -189,7 +325,7 @@ class DocumentationService:
         repo_id: str = repo_response.id
         owner_id: str = repo_response.owner
         dependencies: dict[str, str] = repo_response.dependencies
-        docs: list[FirestoreDoc] = repo_response.docs
+        docs: list[FirestoreDoc] = list(repo_response.docs.values())
 
         repo_formatted = RepoFormatted(name=repo_name, id=repo_id, owner_id=owner_id, tree=[], nodes_map={})
 
@@ -226,11 +362,41 @@ class DocumentationService:
         return repo_formatted
 
     @staticmethod
-    def get_repo_status(repo_response: FirestoreRepo) -> list[dict[str, DocStatusEnum]]:
+    def get_repo_status(repo_response: FirestoreRepo) -> list[dict[str, StatusEnum]]:
         docs = repo_response.docs
 
-        repo_status = [{doc.id: doc.status} for doc in docs]
+        repo_status = [{doc.id: doc.status} for doc in docs.values()]
         return repo_status
+
+    @staticmethod
+    def _validate_folder_and_files(folder: FirestoreDoc, files: List[FirestoreDoc]) -> None:
+        if not folder or folder.type != FirestoreDocType.DIRECTORY:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Folder cannot be empty")
+        for file in files:
+            if file.status != StatusEnum.COMPLETED:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                    detail="Files are still being generated")
+
+    @staticmethod
+    def _validate_doc_and_dependencies(parent: FirestoreDoc, dependencies: List[FirestoreDoc]) -> None:
+        if parent.type == FirestoreDocType.DIRECTORY and not dependencies:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                detail="Dependencies cannot be empty")
+        for dep in dependencies:
+            if dep.status != StatusEnum.COMPLETED:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                    detail="Dependencies are not completed yet.")
+
+    @staticmethod
+    def _validate_repo(repo: FirestoreRepo) -> None:
+        if not repo.dependencies or not repo.root_doc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Repo does not have a root or dependencies.")
+
+        if repo.status == StatusEnum.IN_PROGRESS:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail="Repo is already in progress.")
 
     @staticmethod
     def _validate_json(json_string: str) -> Dict[str, Any] | None:
@@ -241,14 +407,21 @@ class DocumentationService:
             return None
 
     @staticmethod
-    async def _run_concurrently(coroutines: List[Coroutine]) -> tuple[BaseException | Any]:
+    async def _run_concurrently(
+            coroutines: List[Coroutine],
+            batch_size: Optional[int] = None
+    ) -> tuple[BaseException | Any]:
         """This method leverages the asyncio library to run Coroutines concurrently.
         :returns: an ordered tuple with the results of the coroutines, including exceptions
         """
-        tasks = []
-        for coroutine in coroutines:
-            tasks.append(asyncio.ensure_future(coroutine))
-        return await asyncio.gather(*tasks, return_exceptions=True)
+        if batch_size:
+            results = []
+            for i in range(0, len(coroutines), batch_size):
+                batch = coroutines[i:i + batch_size]
+                results.extend(await asyncio.gather(*batch, return_exceptions=True))
+            return tuple(results)
+        else:
+            return await asyncio.gather(*coroutines, return_exceptions=True)
 
 
 def get_documentation_service() -> DocumentationService:
@@ -279,12 +452,12 @@ if __name__ == "__main__":
     # Example of making concurrent requests
     # Note: we are running a protected method (_run_concurrently) just for demo purposes,
     # this member should only be run internally within DocumentationService.
-    files = ["https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py",
-             "https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py",
-             "https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py"]
-    result = asyncio.run(service._run_concurrently(
-        [service.generate_doc_for_file(files[0]),
-         service.generate_doc_for_file(files[1]),
-         service.generate_doc_for_file(files[2])]
-    ))
-    print(result)
+    # test_files = ["https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py",
+    #          "https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py",
+    #          "https://github.com/KTujjar/rocketdocs/blob/main/services/documentation_service.py"]
+    # result = asyncio.run(service._run_concurrently(
+    #     [service.generate_doc_for_file(test_files[0]),
+    #      service.generate_doc_for_file(test_files[1]),
+    #      service.generate_doc_for_file(test_files[2])]
+    # ))
+    # print(result)

--- a/services/identifier_service.py
+++ b/services/identifier_service.py
@@ -46,7 +46,6 @@ class IdentifierService:
             owner=user_id,
         )
 
-        # docs = [root]
         docs = {root.id: root}
         dependencies = {root.id: None}
 


### PR DESCRIPTION
Introduced logic that generates documentation for all the files and folders in a Repository.
1. we treat the Repo as a tree
2. for each leaf node, we generate docs, and remove them from the tree
3. repeat step 2 until no more nodes are left.

### Endpoints
- `POST /repos`: updated with generation logic
- `GET /repos/{repo_id}/{doc_id}`: created

### Side notes
- not currently setting commitId in Repo's `version` field. Could not find it from the GitHub-provided content.
- FirestoreRepo's `docs` field is now a HashMap. Makes it way easier to update individual map items when they are `COMPLETED`.
- Adding something like "Remember to respond in less than 100 words." or "Remember to be concise." at the end of prompts has improved success rates by a lot.
- The LLM no longer generates a `dependency` section in its output. Temporarily improves success rates.
- Similar to above ^^, I've toned down the amount of Markdown text it generates to increase chances of success.