### PR TITLE
Repo Delete Endpoint

### DIFF
--- a/routers/repos.py
+++ b/routers/repos.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter, Depends, BackgroundTasks, HTTPException
 from starlette import status
 
 from schemas.documentation_generation import GetRepoResponse, GetReposResponse, ReposResponseModel, \
-    CreateRepoDocsRequest, CreateRepoDocsResponse, FirestoreRepo, LlmModelEnum, GetFileDocsResponse
+    CreateRepoDocsRequest, CreateRepoDocsResponse, FirestoreRepo, LlmModelEnum, GetFileDocsResponse, \
+    DeleteRepoResponse
 from services.documentation_service import DocumentationService, get_documentation_service
 from routers.utils.auth import get_user_token
 from services.github_service import GithubService, get_github_service
@@ -51,6 +52,21 @@ async def get_repo(
     return GetRepoResponse(repo=repo_formatted)
 
 
+@router.delete("/repos/{repo_id}")
+async def delete_repo(
+        repo_id: str,
+        data_service: DataService = Depends(get_data_service),
+        user: Dict[str, Any] = Depends(get_user_token),
+) -> DeleteRepoResponse:
+    user_id = user.get("uid")
+
+    repo_id = data_service.batch_delete_user_repo(user_id, repo_id)
+    
+    return DeleteRepoResponse(
+        message=f"The data associated with id='{repo_id}' was deleted.",
+        id=repo_id
+    )
+
 @router.get("/repos/{repo_id}/{doc_id}")
 async def get_repo_doc(
         repo_id: str,
@@ -91,3 +107,4 @@ async def create_repo_docs(
         id=firestore_repo.id
     )
 
+GetRepoResponse

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -54,8 +54,7 @@ class FirestoreRepo(BaseModel):
     id: Optional[str] = None
     dependencies: Optional[Dict[str, str | None]] = None
     root_doc: Optional[str] = None
-    docs: Optional[
-        Dict[str, FirestoreDoc]] = None  # {doc_id_1: {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}}
+    docs: Optional[Dict[str, FirestoreDoc]] = None  # {doc_id_1: {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}}
     version: Optional[str] = None  # commitId
     repo_name: Optional[str] = None
     status: Optional[StatusEnum] = None
@@ -80,7 +79,7 @@ class FirestoreBatchOp(BaseModel):
     type: FirestoreBatchOpType
     # This should be a DocumentReference, but Pydantic has some issues with it
     reference: Any
-    data: Dict[str, Any]
+    data: Optional[Dict[str, Any]] = None
 
 
 # POST /file-docs
@@ -200,6 +199,11 @@ class RepoFormatted(BaseModel):
 class GetRepoResponse(BaseModel):
     repo: RepoFormatted
 
+# DELETE /repos/{repo_id}
+class DeleteRepoResponse(BaseModel):
+    message: str
+    id: str
+
 
 # GET /repos
 
@@ -222,3 +226,4 @@ class CreateRepoDocsRequest(BaseModel):
 class CreateRepoDocsResponse(BaseModel):
     message: str
     id: str
+

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -140,13 +140,13 @@ class DataService:
     def batch_delete_user_repo(self, user_id: str, repo_id: str) -> str:
         repo = FirestoreRepo(**self.get_user_repo(user_id, repo_id))
 
-        if repo.status == StatusEnum.IN_PROGRESS:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                                detail=f"Data is still being generated for this repo, so it cannot be deleted yet.")
-
         if repo.owner != user_id:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
                                 detail=f"{user_id} is not the owner of repo with id {repo_id}.")
+
+        if repo.status == StatusEnum.IN_PROGRESS:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=f"Data is still being generated for this repo, so it cannot be deleted yet.")
 
         batch_ops = []
 

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -140,10 +140,6 @@ class DataService:
     def batch_delete_user_repo(self, user_id: str, repo_id: str) -> str:
         repo = FirestoreRepo(**self.get_user_repo(user_id, repo_id))
 
-        if repo.owner != user_id:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
-                                detail=f"{user_id} is not the owner of repo with id {repo_id}.")
-
         if repo.status == StatusEnum.IN_PROGRESS:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                                 detail=f"Data is still being generated for this repo, so it cannot be deleted yet.")


### PR DESCRIPTION
## ```DELETE /repo/repo_id```
```
Response: {
    message: str,
    id: str
}
```

### Notes
Batch deletes the documentation for files/folders first, deleting the repo dbdocument at the end of the batch