### PR TITLE
added markdown fallback and disabled json temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ annotated-types==0.6.0
 anyio==4.2.0
 async-timeout==4.0.3
 attrs==23.2.0
+beautifulsoup4==4.12.3
 CacheControl==0.13.1
 cachetools==5.3.2
 certifi==2023.11.17
@@ -39,6 +40,7 @@ httpx==0.26.0
 idna==3.6
 instructor==0.5.2
 markdown-it-py==3.0.0
+marko==2.0.2
 mdurl==0.1.2
 msgpack==1.0.7
 multidict==6.0.5
@@ -65,6 +67,7 @@ rsa==4.9
 simplejson==3.19.2
 six==1.16.0
 sniffio==1.3.0
+soupsieve==2.5
 starlette==0.35.1
 tenacity==8.2.3
 tqdm==4.66.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ PyYAML==6.0.1
 requests==2.31.0
 rich==13.7.0
 rsa==4.9
+simplejson==3.19.2
 six==1.16.0
 sniffio==1.3.0
 starlette==0.35.1

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -1,9 +1,7 @@
-import uuid
-from typing import ClassVar, Dict, Any, List, Optional, Type
+from typing import ClassVar, Dict, Any, List, Optional
 
-from google.cloud.firestore_v1 import DocumentReference
 from openai.types import CompletionUsage
-from pydantic import BaseModel, constr, conlist, ValidationError, Field
+from pydantic import BaseModel, Field
 from enum import Enum
 import json
 

--- a/services/_prompts.py
+++ b/services/_prompts.py
@@ -75,8 +75,8 @@ print('Marks obtained:',mark)
 Finally, the script thanks the user for playing and prints their score before exiting.
 [END OF EXPECTED RESPONSE]"""
 
-NO_SHOT_FOLDER_SYS_PROMPT = """Your job is to format received input into concise documentation. Respond in Markdown text."""
+NO_SHOT_FOLDER_SYS_PROMPT = """Your job is to generate concise high-level documentation of a folder given its contents. Respond in Markdown text. The first heading will be a small summary of the folder's purpose."""
 
 # For JSON responses
-FILE_JSON_SYS_PROMPT = """Your job is to generate concise high-level documentation of a file, based on its code. Respond in JSON."""
-FOLDER_JSON_SYS_PROMPT = """Your job is to generate concise high-level documentation of a folder, based on the description of its contents. Respond in JSON."""
+NO_SHOT_FILE_JSON_SYS_PROMPT = """Your job is to generate concise high-level documentation of a file, based on its code. Respond concisely. Output JSON."""
+NO_SHOT_FOLDER_JSON_SYS_PROMPT = """Your job is to generate concise high-level documentation of a folder given its contents. Respond in JSON."""

--- a/services/clients/anyscale_client.py
+++ b/services/clients/anyscale_client.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import os
 from typing import Type
 
@@ -66,8 +66,8 @@ class AnyscaleClient(LLMClient):
         try:
             parsed_json = json.loads(completion.choices[0].message.content)
             content = response_model(**parsed_json)
-        except json.JSONDecodeError:
-            raise RuntimeError("LLM output not parsable")
+        except json.JSONDecodeError as e:
+            raise ValueError("LLM output not parsable")
 
         llm_json_response = LlmJsonResponse(
             content=content,


### PR DESCRIPTION
- Disabled our JSON calls for now. Using the first Markdown heading and its content to provide the `description` field we used to extract.

### noticeable effects
- Have not encountered any failure states during my local testing.
- Accuracy has been reduced a tiny bit. Sometimes the first paragraph of a File/Folder doc doesn't provide a good high-level description/summary.
  - This could be improved with better prompts.