### PR TITLE
Separate Identification API from Generation API

### DIFF
--- a/routers/repos.py
+++ b/routers/repos.py
@@ -123,7 +123,7 @@ async def create_repo_docs(
     )
 
 
-@router.post("/repos/upload")
+@router.post("/repos/identify")
 async def upload_repo(
     request: UploadRepoRequest,
     identifier_service: IdentifierService = Depends(get_identifier_service),

--- a/routers/repos.py
+++ b/routers/repos.py
@@ -3,10 +3,24 @@ from typing import Dict, Any
 from fastapi import APIRouter, Depends, BackgroundTasks, HTTPException
 from starlette import status
 
-from schemas.documentation_generation import GetRepoResponse, GetReposResponse, ReposResponseModel, \
-    CreateRepoDocsRequest, CreateRepoDocsResponse, FirestoreRepo, LlmModelEnum, GetFileDocsResponse, \
-    DeleteRepoResponse
-from services.documentation_service import DocumentationService, get_documentation_service
+from schemas.documentation_generation import (
+    GenerateRepoDocsResponse,
+    GetRepoResponse,
+    GetReposResponse,
+    ReposResponseModel,
+    CreateRepoDocsRequest,
+    CreateRepoDocsResponse,
+    FirestoreRepo,
+    LlmModelEnum,
+    GetFileDocsResponse,
+    DeleteRepoResponse,
+    UploadRepoRequest,
+    UploadRepoResponse,
+)
+from services.documentation_service import (
+    DocumentationService,
+    get_documentation_service,
+)
 from services.github_service import GithubService, get_github_service
 from services.identifier_service import IdentifierService, get_identifier_service
 from services.data_service import DataService, get_data_service
@@ -18,8 +32,8 @@ router = APIRouter()
 # for now returns all repos ids, no users yet
 @router.get("/repos")
 async def get_repos(
-        data_service: DataService = Depends(get_data_service),
-        user: Dict[str, Any] = Depends(utils.get_user_token),
+    data_service: DataService = Depends(get_data_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
 ) -> GetReposResponse:
     user_id = user.get("uid")
 
@@ -30,80 +44,118 @@ async def get_repos(
             name=repo.repo_name,
             id=repo.id,
             status=repo.status,
-            docs_status=[{doc.id: doc.status} for doc in repo.docs.values()]
+            docs_status=[{doc.id: doc.status} for doc in repo.docs.values()],
         )
         for repo in repos
     ]
-    
+
     return GetReposResponse(repos=repos_formatted)
 
 
 @router.get("/repos/{repo_id}")
 async def get_repo(
-        repo_id: str,
-        data_service: DataService = Depends(get_data_service),
-        user: Dict[str, Any] = Depends(utils.get_user_token),
+    repo_id: str,
+    data_service: DataService = Depends(get_data_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
 ) -> GetRepoResponse:
     user_id = user.get("uid")
 
     repo_dict = data_service.get_user_repo(user_id, repo_id)
     repo = FirestoreRepo(**repo_dict)
     repo_formatted = utils.format_repo(repo)
-    
+
     return GetRepoResponse(repo=repo_formatted)
 
 
 @router.delete("/repos/{repo_id}")
 async def delete_repo(
-        repo_id: str,
-        data_service: DataService = Depends(get_data_service),
-        user: Dict[str, Any] = Depends(utils.get_user_token),
+    repo_id: str,
+    data_service: DataService = Depends(get_data_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
 ) -> DeleteRepoResponse:
     user_id = user.get("uid")
 
     repo_id = data_service.batch_delete_user_repo(user_id, repo_id)
-    
+
     return DeleteRepoResponse(
-        message=f"The data associated with id='{repo_id}' was deleted.",
-        id=repo_id
+        message=f"The data associated with id='{repo_id}' was deleted.", id=repo_id
     )
+
 
 @router.get("/repos/{repo_id}/{doc_id}")
 async def get_repo_doc(
-        repo_id: str,
-        doc_id: str,
-        data_service: DataService = Depends(get_data_service),
-        user: Dict[str, Any] = Depends(utils.get_user_token),
+    repo_id: str,
+    doc_id: str,
+    data_service: DataService = Depends(get_data_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
 ) -> GetFileDocsResponse:
     user_id = user.get("uid")
     doc = data_service.get_user_documentation(user_id, doc_id)
 
     if doc.repo != repo_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Document does not belong to the repo")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Document does not belong to the repo",
+        )
 
     return GetFileDocsResponse(**doc.model_dump())
 
 
 @router.post("/repos")
 async def create_repo_docs(
-        request: CreateRepoDocsRequest,
-        background_tasks: BackgroundTasks,
-        identifier_service: IdentifierService = Depends(get_identifier_service),
-        github_service: GithubService = Depends(get_github_service),
-        documentation_service: DocumentationService = Depends(get_documentation_service),
-        user: Dict[str, Any] = Depends(utils.get_user_token),
-        model: LlmModelEnum = LlmModelEnum.MIXTRAL
+    request: CreateRepoDocsRequest,
+    background_tasks: BackgroundTasks,
+    identifier_service: IdentifierService = Depends(get_identifier_service),
+    github_service: GithubService = Depends(get_github_service),
+    documentation_service: DocumentationService = Depends(get_documentation_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
+    model: LlmModelEnum = LlmModelEnum.MIXTRAL,
 ) -> CreateRepoDocsResponse:
     user_id = user.get("uid")
     github_repo = github_service.get_repo_from_url(request.github_url)
     firestore_repo = identifier_service.identify(github_repo, user_id)
     documentation_service.enqueue_generate_repo_docs_job(
-        background_tasks,
-        firestore_repo,
-        model
+        background_tasks, firestore_repo, model
     )
 
     return CreateRepoDocsResponse(
-        message="Documentation generation has been started.",
-        id=firestore_repo.id
+        message="Documentation generation has been started.", id=firestore_repo.id
+    )
+
+
+@router.post("/repos/upload")
+async def upload_repo(
+    request: UploadRepoRequest,
+    identifier_service: IdentifierService = Depends(get_identifier_service),
+    github_service: GithubService = Depends(get_github_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
+) -> UploadRepoResponse:
+    user_id = user.get("uid")
+    github_repo = github_service.get_repo_from_url(request.github_url)
+    firestore_repo = identifier_service.identify(github_repo, user_id)
+
+    return UploadRepoResponse(
+        message="Files and folders have been identified for documentation.",
+        id=firestore_repo.id,
+        items_to_document=firestore_repo.get_identified_docs(),
+    )
+
+
+@router.post("/repos/{repo_id}/generate")
+async def generate_repo_docs(
+    repo_id: str,
+    background_tasks: BackgroundTasks,
+    documentation_service: DocumentationService = Depends(get_documentation_service),
+    data_service: DataService = Depends(get_data_service),
+    user: Dict[str, Any] = Depends(utils.get_user_token),
+    model: LlmModelEnum = LlmModelEnum.MIXTRAL,
+) -> GenerateRepoDocsResponse:
+    user_id = user.get("uid")
+    repo_dict = data_service.get_user_repo(user_id, repo_id)
+    repo = FirestoreRepo(**repo_dict)
+
+    documentation_service.enqueue_generate_repo_docs_job(background_tasks, repo, model)
+
+    return GenerateRepoDocsResponse(
+        message="Documentation generation has been started.", id=repo.id
     )

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -61,6 +61,7 @@ class FirestoreDoc(BaseModel):
 
 
 class IdentifiedItemToDocument(BaseModel):
+    type: FirestoreDocType
     id: str
     path: str
 
@@ -81,7 +82,7 @@ class FirestoreRepo(BaseModel):
         if self.docs is None:
             return []
         return [
-            IdentifiedItemToDocument(id=doc.id, path=doc.relative_path)
+            IdentifiedItemToDocument(id=doc.id, path=doc.relative_path, type=doc.type)
             for doc in self.docs.values()
         ]
 

--- a/schemas/documentation_generation.py
+++ b/schemas/documentation_generation.py
@@ -12,32 +12,38 @@ class LlmProvider(str, Enum):
 
 
 class LlmModelEnum(str, Enum):
-    MIXTRAL = 'mistralai/Mixtral-8x7B-Instruct-v0.1'
-    MISTRAL = 'mistralai/Mistral-7B-Instruct-v0.1'
-    MISTRAL_ORCA = 'Open-Orca/Mistral-7B-OpenOrca'
-    LLAMA_7B = 'meta-llama/Llama-2-7b-chat-hf'
-    GPT3_TURBO = 'gpt-3.5-turbo-0125'
-    GPT4_TURBO = 'gpt-4-turbo-preview'
+    MIXTRAL = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    MISTRAL = "mistralai/Mistral-7B-Instruct-v0.1"
+    MISTRAL_ORCA = "Open-Orca/Mistral-7B-OpenOrca"
+    LLAMA_7B = "meta-llama/Llama-2-7b-chat-hf"
+    GPT3_TURBO = "gpt-3.5-turbo-0125"
+    GPT4_TURBO = "gpt-4-turbo-preview"
 
     def belongs_to(self) -> LlmProvider:
         if self in [LlmModelEnum.GPT3_TURBO, LlmModelEnum.GPT4_TURBO]:
             return LlmProvider.OPENAI
-        elif self in [LlmModelEnum.MIXTRAL, LlmModelEnum.MISTRAL, LlmModelEnum.MISTRAL_ORCA, LlmModelEnum.LLAMA_7B]:
+        elif self in [
+            LlmModelEnum.MIXTRAL,
+            LlmModelEnum.MISTRAL,
+            LlmModelEnum.MISTRAL_ORCA,
+            LlmModelEnum.LLAMA_7B,
+        ]:
             return LlmProvider.ANYSCALE
 
 
 class StatusEnum(str, Enum):
-    NOT_STARTED = 'NOT STARTED'
-    IN_PROGRESS = 'IN PROGRESS'
-    COMPLETED = 'COMPLETED'
-    FAILED = 'FAILED'
+    NOT_STARTED = "NOT STARTED"
+    IN_PROGRESS = "IN PROGRESS"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
 
 
 # Firestore Models
 
+
 class FirestoreDocType(str, Enum):
-    FILE = 'file'
-    DIRECTORY = 'dir'
+    FILE = "file"
+    DIRECTORY = "dir"
 
 
 class FirestoreDoc(BaseModel):
@@ -54,26 +60,40 @@ class FirestoreDoc(BaseModel):
     owner: Optional[str] = None
 
 
+class IdentifiedItemToDocument(BaseModel):
+    id: str
+    path: str
+
+
 class FirestoreRepo(BaseModel):
     id: Optional[str] = None
     dependencies: Optional[Dict[str, str | None]] = None
     root_doc: Optional[str] = None
-    docs: Optional[
-        Dict[str, FirestoreDoc]] = None  # {doc_id_1: {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}}
+    docs: Optional[Dict[str, FirestoreDoc]] = (
+        None  # {doc_id_1: {id: "doc_id_1", path: "/README.md", status: "COMPLETED"}}
+    )
     version: Optional[str] = None  # commitId
     repo_name: Optional[str] = None
     status: Optional[StatusEnum] = None
     owner: Optional[str] = None
 
+    def get_identified_docs(self) -> List[IdentifiedItemToDocument]:
+        if self.docs is None:
+            return []
+        return [
+            IdentifiedItemToDocument(id=doc.id, path=doc.relative_path)
+            for doc in self.docs.values()
+        ]
+
 
 class FirestoreBatchOpType(str, Enum):
-    SET = 'SET'
-    UPDATE = 'UPDATE'
-    DELETE = 'DELETE'
+    SET = "SET"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
 
 
 class FirestoreQuery(BaseModel):
-    OP_STRING_EQUALS: ClassVar[str] = '=='
+    OP_STRING_EQUALS: ClassVar[str] = "=="
 
     field_path: str
     op_string: str
@@ -89,6 +109,7 @@ class FirestoreBatchOp(BaseModel):
 
 # POST /file-docs
 
+
 class GenerateFileDocsRequest(BaseModel):
     github_url: str
 
@@ -100,6 +121,7 @@ class GenerateFileDocsResponse(BaseModel):
 
 # GET /file-docs/{id}
 
+
 class GetFileDocsResponse(BaseModel):
     id: str
     github_url: str
@@ -110,6 +132,7 @@ class GetFileDocsResponse(BaseModel):
 
 # DELETE /file-docs/{id}
 
+
 class DeleteFileDocsResponse(BaseModel):
     message: str
     id: str
@@ -117,12 +140,14 @@ class DeleteFileDocsResponse(BaseModel):
 
 # UPDATE /file-docs/{id}
 
+
 class UpdateFileDocsResponse(BaseModel):
     message: str
     id: str
 
 
 # LLM Generation Models
+
 
 class GeneratedDoc(BaseModel):
     relative_path: str
@@ -138,22 +163,27 @@ class LlmJsonResponse(BaseModel):
 
 
 class LlmFileDocSchema(BaseModel):
-    description: str = Field("Around 100 words about the code's purpose. Remember to be concise.")
+    description: str = Field(
+        "Around 100 words about the code's purpose. Remember to be concise."
+    )
     # dependencies: List[str] = Field("Outside dependencies the code uses")
 
 
 class LlmFolderDocSchema(BaseModel):
-    description: str = Field("Around 100 words about the overall purpose. Remember to be concise.")
+    description: str = Field(
+        "Around 100 words about the overall purpose. Remember to be concise."
+    )
 
 
 # repo tree
+
 
 class RepoNode(BaseModel):
     id: str
     path: str
     type: FirestoreDocType
     completion_status: StatusEnum
-    children: list['RepoNode'] = []
+    children: list["RepoNode"] = []
 
 
 class RepoFormatted(BaseModel):
@@ -164,17 +194,18 @@ class RepoFormatted(BaseModel):
     tree: list[RepoNode]
     nodes_map: dict[str, RepoNode] = Field(exclude=True)  # id to RepoNode
 
-    def insert_node(self,
-                    parent: FirestoreDoc,
-                    child: FirestoreDoc,
-                    ) -> None:
+    def insert_node(
+        self,
+        parent: FirestoreDoc,
+        child: FirestoreDoc,
+    ) -> None:
         if parent.id in self.nodes_map.keys():
             child_node = RepoNode(
                 id=child.id,
                 path=child.relative_path,
                 type=child.type,
                 completion_status=child.status,
-                children=[]
+                children=[],
             )  # place holder type and status
             self.nodes_map[parent.id].children.append(child_node)
             self.nodes_map[child.id] = child_node
@@ -185,14 +216,14 @@ class RepoFormatted(BaseModel):
                 path=child.relative_path,
                 type=child.type,
                 completion_status=child.status,
-                children=[]
+                children=[],
             )  # place holder type and status
             parent_node = RepoNode(
                 id=parent.id,
                 path=parent.relative_path,
                 type=parent.type,
                 completion_status=parent.status,
-                children=[child_node]
+                children=[child_node],
             )  # place holder type and status
             self.nodes_map[parent.id] = parent_node
             self.nodes_map[child.id] = child_node
@@ -215,6 +246,7 @@ class RepoFormatted(BaseModel):
 
 # GET /repos/{repo_id}
 
+
 class GetRepoResponse(BaseModel):
     repo: RepoFormatted
 
@@ -226,6 +258,7 @@ class DeleteRepoResponse(BaseModel):
 
 
 # GET /repos
+
 
 class ReposResponseModel(BaseModel):
     name: str
@@ -240,10 +273,36 @@ class GetReposResponse(BaseModel):
 
 # POST /repos
 
+
 class CreateRepoDocsRequest(BaseModel):
     github_url: str
 
 
 class CreateRepoDocsResponse(BaseModel):
+    message: str
+    id: str
+
+
+# POST /repos/upload
+
+
+class UploadRepoRequest(BaseModel):
+    github_url: str
+
+
+class UploadRepoResponse(BaseModel):
+    message: str
+    id: str
+    items_to_document: list[IdentifiedItemToDocument]
+    estimated_cost: Optional[int] = None
+
+
+# class GenerateRepoDocsRequest(BaseModel):
+# todo: add items_to_document field here for frontend to be able to send us the user modified list
+# would need to add a new status to files and have files we identified as no be denoted as such in docs field of firestore repo
+# items_to_document: list[IdentifiedItemToDocument]
+
+
+class GenerateRepoDocsResponse(BaseModel):
     message: str
     id: str


### PR DESCRIPTION
## POST /repos/identify
For uploading the GitHub URL and getting back the identified documents
### Request:
```
{
    github_url: str
}
```
### Response:
```
{
    message: str
    id: str
    items_to_document: list[IdentifiedItemToDocument]
    estimated_cost: int         # not implemented
}
```

## POST /repos/{repo_id}/generate
For uploading a repo_id that has been identified and starting the documentation process
### Request [Future] 
```
{
    [Optional] items_to_document: list[item id]     # allow users to modify what they want documented
}
```
### Response
```
{
    message: str
    id: str
}
```