### PR TITLE
Ryanata/search

### DIFF
--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -25,6 +25,7 @@ from schemas.documentation_generation import (
 from services.clients.anyscale_client import get_anyscale_client
 from services.clients.openai_client import get_openai_client
 from services.data_service import DataService, get_data_service
+from services.rag_service.embedding_service import EmbeddingService, get_embedding_service
 from fastapi import BackgroundTasks, HTTPException, status
 
 from dotenv import load_dotenv
@@ -45,10 +46,12 @@ class DocumentationService:
         llm_client: LLMClient,
         github_service: GithubService,
         data_service: DataService,
+        embedding_service: EmbeddingService,
     ):
         self.llm_client = llm_client
         self.github_service = github_service
         self.data_service = data_service
+        self.embedding_service = embedding_service
         self.system_prompt_for_file_json = NO_SHOT_FILE_JSON_SYS_PROMPT
         self.system_prompt_for_folder_json = NO_SHOT_FOLDER_JSON_SYS_PROMPT
         self.system_prompt_for_folder_markdown = NO_SHOT_FOLDER_SYS_PROMPT
@@ -136,7 +139,7 @@ class DocumentationService:
 
         return doc_id
 
-    async def generate_repo_docs_background_task(
+    async def generate_repo_docs(
         self, firestore_repo: FirestoreRepo, model: LlmModelEnum
     ) -> None:
         self._validate_repo(firestore_repo)
@@ -177,19 +180,17 @@ class DocumentationService:
             firestore_repo.id, FirestoreRepo(status=StatusEnum.COMPLETED)
         )
 
-    def enqueue_generate_repo_docs_job(
-        self,
-        background_tasks: BackgroundTasks,
-        firestore_repo: FirestoreRepo,
-        model: LlmModelEnum,
+    async def generate_repo_docs_and_embed_background_task(
+            self,
+            firestore_repo: FirestoreRepo,
+            model: LlmModelEnum,
+            user_id: str,
     ):
         self.data_service.update_repo(
             firestore_repo.id, FirestoreRepo(status=StatusEnum.IN_PROGRESS)
         )
-
-        background_tasks.add_task(
-            self.generate_repo_docs_background_task, firestore_repo, model
-        )
+        await self.generate_repo_docs(firestore_repo, model)
+        await self.embedding_service.generate_markdown_embeddings_for_repo(firestore_repo.id, user_id)
 
     def regenerate_doc(
         self,
@@ -426,7 +427,8 @@ def get_documentation_service(
 
     github_service = get_github_service()
     data_service = get_data_service()
-    return DocumentationService(llm_client, github_service, data_service)
+    embedding_service = get_embedding_service()
+    return DocumentationService(llm_client, github_service, data_service, embedding_service)
 
 
 # For manually testing this file

--- a/services/rag_service/embedding_service.py
+++ b/services/rag_service/embedding_service.py
@@ -8,6 +8,7 @@ from schemas.documentation_generation import FirestoreDoc, FirestoreRepo,Embeddi
 from collections import deque 
 from routers import utils
 from dotenv import load_dotenv
+from pinecone.core.client.exceptions import NotFoundException
 import firebase_admin
 import os
 import asyncio
@@ -96,6 +97,12 @@ class EmbeddingService:
                     self.vector_database_client.upsert(vectors, repo_id)
                     vectors = []
                 chunk_index += 1
+    
+    def delete_repo(self, repo_id: str):
+        try:
+            self.vector_database_client.delete(repo_id)
+        except NotFoundException:
+            print(f"Can't delete repo with id '{repo_id}' because it never existed in Pinecone DB.")
                 
 def get_embedding_service():
     embedding_client = get_anyscale_client()

--- a/services/rag_service/search_service.py
+++ b/services/rag_service/search_service.py
@@ -1,0 +1,48 @@
+from services.data_service import DataService, get_data_service
+from services.clients.pinecone_client import PineconeClient, get_pinecone_client
+from services.clients.anyscale_client import AnyscaleClient, get_anyscale_client
+from schemas.documentation_generation import EmbeddingModelEnum
+from fastapi import HTTPException, status
+
+
+class SearchService:
+    def __init__(
+        self,
+        embedding_client: AnyscaleClient,
+        vector_database_client: PineconeClient,
+        data_service: DataService,
+    ):
+        self.embedding_client = embedding_client
+        self.vector_database_client = vector_database_client
+        self.data_service = data_service
+
+    async def search(self, repo_id: str, query: str, user_id: str):
+        # 1. Generate embedding for the query
+        query_embedding = await self.embedding_client.generate_embedding(
+            model=EmbeddingModelEnum.BGE_LARGE, input=query
+        )
+
+        # 2. Query the vector database
+        results = self.vector_database_client.query(
+            namespace=repo_id, query_vector=query_embedding.data[0].embedding, top_k=4, include_metadata=True
+        )
+
+        # 3. Retrieve and format the results
+        formatted_results = []
+        for match in results.matches:
+            formatted_results.append(
+                {
+                    "doc_id": match.metadata["doc_id"],
+                    "score": match.score,
+                    "chunk_content": match.metadata["chunk_content"],
+                }
+            )
+
+        return formatted_results
+
+
+def get_search_service():
+    embedding_client = get_anyscale_client()
+    vector_database_client = get_pinecone_client()
+    data_service = get_data_service()
+    return SearchService(embedding_client, vector_database_client, data_service)

--- a/services/rag_service/text_chunker.py
+++ b/services/rag_service/text_chunker.py
@@ -38,7 +38,7 @@ class TextChunker:
                 # Else if, we can merge with next chunk, merge
                 # Else just leave it alone
 
-                if i > 0 and self._len(processed_chunks[-1]) + self._len(chunks[i]) <= self.chunk_size:
+                if i > 0 and processed_chunks and self._len(processed_chunks[-1]) + self._len(chunks[i]) <= self.chunk_size:
                     processed_chunks[-1] += chunks[i]
                 elif i < len(chunks) - 1 and self._len(chunks[i]) + self._len(chunks[i+1]) <= self.chunk_size:
                     chunks[i+1] = chunks[i] + chunks[i+1]


### PR DESCRIPTION
### Added new endpoint
`/repos/{repo_id}/search`
- added SearchService to supplement this new endpoint

### Modifications to integrate new Embedding service
- DELETE `/repos/{repo_id}` now deletes the vector DB namespace alongside the Firestore entry
- Embedding service is now ran in the `DocumentationService` after all files have been documented
- Phased out POST `/repos`