### PR TITLE
Updated folder prompt

### DIFF
--- a/services/_prompts.py
+++ b/services/_prompts.py
@@ -75,7 +75,7 @@ print('Marks obtained:',mark)
 Finally, the script thanks the user for playing and prints their score before exiting.
 [END OF EXPECTED RESPONSE]"""
 
-NO_SHOT_FOLDER_SYS_PROMPT = """
+ONE_SHOT_FOLDER_SYS_PROMPT = """
 You are a highly skilled engineer tasked with writing documentation for a specific folder in a codebase. Clients will provide you with the following information:
 1. The name of the folder you need to document.
 2. The underlying files and folders in the folder, along with a short description of each.

--- a/services/_prompts.py
+++ b/services/_prompts.py
@@ -75,7 +75,42 @@ print('Marks obtained:',mark)
 Finally, the script thanks the user for playing and prints their score before exiting.
 [END OF EXPECTED RESPONSE]"""
 
-NO_SHOT_FOLDER_SYS_PROMPT = """Your job is to generate concise high-level documentation of a folder given its contents. Respond in Markdown text. The first heading will be a small summary of the folder's purpose."""
+NO_SHOT_FOLDER_SYS_PROMPT = """
+You are a highly skilled engineer tasked with writing documentation for a specific folder in a codebase. Clients will provide you with the following information:
+1. The name of the folder you need to document.
+2. The underlying files and folders in the folder, along with a short description of each.
+
+Your task is to generate a concise and interconnected summary of the folder's contents in a markdown format. Avoid making assumptions about the code structure or functionality based on the provided descriptions. Instead, focus on highlighting the purpose and role of each file and folder in the context of the overall project. If you're unsure about something, simply omit it your response.
+
+For example:
+
+<USER>
+The folder I need documented is `app/routes`. It contains the following files/folders:
+1. `index.js`: `app/routes/index.js` is the main entry point for all routes. It imports and uses all other route files.
+2. `users.js`: `app/routes/users.js` contains all routes related to user operations like login, signup, and profile updates.
+3. `products.js`: `app/routes/product.js` contains all routes related to product operations like adding new products, updating existing products, and deleting products.
+</USER>
+
+A suitable response would be:
+
+# `app/routes` Folder Documentation
+
+This folder contains the route handlers for the application. Each file is responsible for defining routes for different aspects of the application.
+
+## Files
+
+### `index.js`
+
+The `index.js` file is the main entry point for all routes. It imports and uses all other route files. This allows for a modular structure where each aspect of routing is handled by its specific file.
+
+### `users.js`
+
+The `users.js` file contains all routes related to user operations. This includes, but is not limited to, operations like login, signup, and profile updates. Each route defined in this file should correspond to a specific user operation.
+
+### `products.js`
+
+The `products.js` file contains all routes related to product operations. This includes operations like adding new products, updating existing products, and deleting products. Each route defined in this file should correspond to a specific product operation.
+""".strip()
 
 # For JSON responses
 NO_SHOT_FILE_JSON_SYS_PROMPT = """Your job is to generate concise high-level documentation of a file, based on its code. Respond concisely. Output JSON."""

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -36,7 +36,7 @@ from services._prompts import (
     ONE_SHOT_FILE_SYS_PROMPT,
     NO_SHOT_FILE_JSON_SYS_PROMPT,
     NO_SHOT_FOLDER_JSON_SYS_PROMPT,
-    NO_SHOT_FOLDER_SYS_PROMPT,
+    ONE_SHOT_FOLDER_SYS_PROMPT,
 )
 
 
@@ -54,7 +54,7 @@ class DocumentationService:
         self.embedding_service = embedding_service
         self.system_prompt_for_file_json = NO_SHOT_FILE_JSON_SYS_PROMPT
         self.system_prompt_for_folder_json = NO_SHOT_FOLDER_JSON_SYS_PROMPT
-        self.system_prompt_for_folder_markdown = NO_SHOT_FOLDER_SYS_PROMPT
+        self.system_prompt_for_folder_markdown = ONE_SHOT_FOLDER_SYS_PROMPT
         self.system_prompt_for_file_markdown = ONE_SHOT_FILE_SYS_PROMPT
 
     async def generate_doc(

--- a/services/documentation_service.py
+++ b/services/documentation_service.py
@@ -243,17 +243,9 @@ class DocumentationService:
     ) -> GeneratedDoc:
         self._validate_folder_and_files(folder, files)
 
-        user_prompt_markdown = (
-            "This is the root folder."
-            if not folder.relative_path
-            else f"This is the {folder.relative_path} folder."
-        )
-        user_prompt_markdown += f" It contains:\n" + "\n".join(
-            f"{file.relative_path}: {file.extracted_data.get('description')}"
-            for file in files
-        )
-        user_prompt_markdown += "\nRemember to respond concisely, but accurately."
-
+        folder_path = 'the root folder' if not folder.relative_path else folder.relative_path
+        file_info_list = '\n'.join([f"{i+1}. `{file.relative_path}`: {file.extracted_data.get('description')}" for i, file in enumerate(files)])
+        user_prompt_markdown = f"The folder I need documented is {folder_path}. It contains the following files/folders:\n{file_info_list}"
         return await self._generate_doc_with_fallback(
             model,
             user_prompt_markdown,
@@ -397,13 +389,14 @@ class DocumentationService:
     @staticmethod
     def _extract_first_heading_content(markdown_content: str) -> str:
         parsed = marko.parse(markdown_content)
-        found_heading = False
         heading_content = []
+
         for child in parsed.children:
             if isinstance(child, Heading):
-                if found_heading:
+                if not heading_content:  # Skip the first heading
+                    continue
+                else:
                     break
-                found_heading = True
             html_output = marko.render(child)
             text = BeautifulSoup(html_output, "html.parser").get_text()
             heading_content.append(text)


### PR DESCRIPTION
- Updated folder system prompt
- Changed user prompt in `_generate_doc_for_folder` to fit better with new system prompt
- Changed `_extract_first_heading_content` to exclude the top-level heading in the description of files/folders. Instead of description = "#Doumentation for `test.py`\nThis file is a testing file...`, description now will equal "This file is a testing file..."