### PR TITLE
Lion bot repo should work

### DIFF
--- a/services/rag_service/text_chunker.py
+++ b/services/rag_service/text_chunker.py
@@ -3,6 +3,8 @@ import re
 from typing import List
 from transformers import AutoTokenizer
 
+from schemas.documentation_generation import EmbeddingModelEnum
+
 class TextChunker:
     '''
     Instead of using arbitrary character limit, we use the number of tokens as the chunk size.
@@ -14,7 +16,7 @@ class TextChunker:
         chunk_minimum (int): The minimum number of tokens per chunk
         tokenizer (str): The name of the tokenizer to be used
     '''
-    def __init__(self, chunk_size=250, chunk_minimum=50, tokenizer="BAAI/bge-large-zh-v1.5"):
+    def __init__(self, chunk_size=250, chunk_minimum=50, tokenizer="BAAI/bge-large-en-v1.5"):
         self.chunk_size = chunk_size
         self.chunk_minimum = chunk_minimum
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer)


### PR DESCRIPTION
Made the following changes
- Identifier service has a long list of excluded dirs and files. Credit to sweepai repo for this implementation
- Before passing to LLM, file contents are now forced to be below 28k tokens. We are using mixtral for this implementation, need to update to work with all LLMs in the future.
- Was accidentally using the chinese encoder instead of the english encoder in the textchunker for embeddings